### PR TITLE
Trim expense name, don't crash on bad CSV, clear search

### DIFF
--- a/Oikon.xcodeproj/project.pbxproj
+++ b/Oikon.xcodeproj/project.pbxproj
@@ -190,12 +190,13 @@
 			attributes = {
 				LastSwiftMigration = 0710;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = emotionLoop;
 				TargetAttributes = {
 					4F20403A1A94F3630023D3EB = {
 						CreatedOnToolsVersion = 6.1;
 						DevelopmentTeam = BR4RWWLMM9;
+						LastSwiftMigration = 0830;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
 								enabled = 1;
@@ -207,6 +208,7 @@
 					};
 					4F20404F1A94F3630023D3EB = {
 						CreatedOnToolsVersion = 6.1;
+						LastSwiftMigration = 0830;
 						TestTargetID = 4F20403A1A94F3630023D3EB;
 					};
 				};
@@ -313,8 +315,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -323,6 +327,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -356,8 +361,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -366,6 +373,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -375,6 +383,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -391,6 +400,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.emotionloop.$(PRODUCT_NAME:rfc1034identifier)Mac";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -407,6 +417,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.emotionloop.$(PRODUCT_NAME:rfc1034identifier)Mac";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -427,6 +438,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.emotionloop.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Oikon.app/Contents/MacOS/Oikon";
 			};
 			name = Debug;
@@ -444,6 +456,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.emotionloop.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Oikon.app/Contents/MacOS/Oikon";
 			};
 			name = Release;

--- a/Oikon/AboutViewController.swift
+++ b/Oikon/AboutViewController.swift
@@ -17,13 +17,13 @@ class AboutViewController: NSViewController {
     }
         
     // Open oikon website
-    @IBAction func openWebsite( sender: AnyObject? ) {
-        NSWorkspace.sharedWorkspace().openURL(NSURL(string: "http://oikon.us")!)
+    @IBAction func openWebsite( _ sender: AnyObject? ) {
+        NSWorkspace.shared().open(URL(string: "https://oikon.net")!)
     }
     
     // Open support email
-    @IBAction func openSupportEmail( sender: AnyObject? ) {
-        NSWorkspace.sharedWorkspace().openURL(NSURL(string: "mailto:hello@emotionloop.com")!)
+    @IBAction func openSupportEmail( _ sender: AnyObject? ) {
+        NSWorkspace.shared().open(URL(string: "mailto:hello@emotionloop.com")!)
     }
 }
 

--- a/Oikon/AddExpenseTypeViewController.swift
+++ b/Oikon/AddExpenseTypeViewController.swift
@@ -15,8 +15,8 @@ class AddExpenseTypeViewController: NSViewController {
     @IBOutlet var nameText: NSTextField!
     
     // Add expense type
-    @IBAction func addExpenseType(sender: AnyObject) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    @IBAction func addExpenseType(_ sender: AnyObject) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
         let uncategorizedStringValue = NSLocalizedString("uncategorized", comment: "")
@@ -25,7 +25,7 @@ class AddExpenseTypeViewController: NSViewController {
         var expenseTypeName: NSString = ""
         
         // Avoid empty values crashing the code
-        if let tmpExpenseTypeName: NSString? = self.nameText?.stringValue {
+        if let tmpExpenseTypeName: NSString? = self.nameText?.stringValue as NSString? {
             expenseTypeName = tmpExpenseTypeName!
         }
         
@@ -37,21 +37,21 @@ class AddExpenseTypeViewController: NSViewController {
         
         // Check if the expense type name is not empty
         if ( expenseTypeName.length <= 0 ) {
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Please confirm the name of the expense type.", comment:""), window: self.mainViewController.view.window!)
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Please confirm the name of the expense type.", comment:"") as NSString, window: self.mainViewController.view.window!)
             
             return;
         }
         
         // Check if the expense type name is "uncategorized" (case insensitive, not allowed)
-        if ( expenseTypeName.compare(uncategorizedStringValue) == NSComparisonResult.OrderedSame ) {
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Your expense type can't be called 'uncategorized'.", comment:""), window: self.mainViewController.view.window!)
+        if ( expenseTypeName.compare(uncategorizedStringValue) == ComparisonResult.orderedSame ) {
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Your expense type can't be called 'uncategorized'.", comment:"") as NSString, window: self.mainViewController.view.window!)
 
             return;
         }
         
         // Check if an expense type with that name already exists
         if ( self.mainViewController.expenseTypeExists(expenseTypeName) ) {
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("An expense type with the same name already exists.", comment:""), window: self.mainViewController.view.window!)
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("An expense type with the same name already exists.", comment:"") as NSString, window: self.mainViewController.view.window!)
             
             return;
         }
@@ -64,7 +64,7 @@ class AddExpenseTypeViewController: NSViewController {
         // Save object
         //
         
-        let newExpenseType: NSManagedObject = NSEntityDescription.insertNewObjectForEntityForName("ExpenseType", inManagedObjectContext: context!) 
+        let newExpenseType: NSManagedObject = NSEntityDescription.insertNewObject(forEntityName: "ExpenseType", into: context!) 
 
         newExpenseType.setValue(expenseTypeName, forKey: "name")
         
@@ -86,7 +86,7 @@ class AddExpenseTypeViewController: NSViewController {
         } else {
             NSLog("Error: %@", error!)
             
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("There was an error adding your expense type. Please confirm the value types match.", comment:""), window: self.mainViewController.view.window!)
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("There was an error adding your expense type. Please confirm the value types match.", comment:"") as NSString, window: self.mainViewController.view.window!)
         }
         
         // Close popover

--- a/Oikon/AddExpenseViewController.swift
+++ b/Oikon/AddExpenseViewController.swift
@@ -22,22 +22,22 @@ class AddExpenseViewController: NSViewController {
     @IBOutlet var addExpenseButton: NSButton!
     
     // Add expense
-    @IBAction func addExpense(sender: AnyObject) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    @IBAction func addExpense(_ sender: AnyObject) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let numberFormatter = NSNumberFormatter()
-        numberFormatter.locale = NSLocale.currentLocale()
-        numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale.current
+        numberFormatter.numberStyle = NumberFormatter.Style.decimal
         
         // Set defaults
         var expenseValue: NSNumber = 0
         var expenseName: NSString = ""
-        var expenseType: NSString? = uncategorizedStringValue
-        var expenseDate: NSDate = NSDate()// Default expense date to "now"
+        var expenseType: NSString? = uncategorizedStringValue as NSString
+        var expenseDate: Date = Date()// Default expense date to "now"
         
         // Avoid empty values crashing the code
-        if let tmpExpenseValue: NSNumber = numberFormatter.numberFromString(self.valueText.stringValue) {
+        if let tmpExpenseValue: NSNumber = numberFormatter.number(from: self.valueText.stringValue) {
             expenseValue = tmpExpenseValue
         }
         if let tmpExpenseName: NSString = self.nameText.stringValue as NSString? {
@@ -46,7 +46,7 @@ class AddExpenseViewController: NSViewController {
         if let tmpExpenseType: NSString = self.typeText.titleOfSelectedItem! as NSString? {
             expenseType = tmpExpenseType
         }
-        if let tmpExpenseDate: NSDate = self.dateText.dateValue as NSDate? {
+        if let tmpExpenseDate: Date = self.dateText.dateValue as Date? {
             expenseDate = tmpExpenseDate
         }
         
@@ -58,14 +58,14 @@ class AddExpenseViewController: NSViewController {
         
         // Check if value is greater than 0
         if ( !expenseValue.boolValue ) {
-            self.mainViewController.showAlert(NSLocalizedString("Please confirm the value of the expense.", comment:""), window: self.view.window!)
+            self.mainViewController.showAlert(NSLocalizedString("Please confirm the value of the expense.", comment:"") as NSString, window: self.view.window!)
             
             return;
         }
         
         // Check if the expense name is not empty
         if ( expenseName.length <= 0 ) {
-            self.mainViewController.showAlert(NSLocalizedString("Please confirm the name of the expense.", comment:""), window: self.view.window!)
+            self.mainViewController.showAlert(NSLocalizedString("Please confirm the name of the expense.", comment:"") as NSString, window: self.view.window!)
             
             return;
         }
@@ -75,7 +75,7 @@ class AddExpenseViewController: NSViewController {
         //
         
         // Check if the expense type is empty (if empty or uncategorized, set to nil)
-        if ( expenseType!.length <= 0 || expenseType!.isEqualToString(uncategorizedStringValue) ) {
+        if ( expenseType!.length <= 0 || expenseType!.isEqual(to: uncategorizedStringValue) ) {
             expenseType = nil
         }
         
@@ -83,7 +83,7 @@ class AddExpenseViewController: NSViewController {
         // Save object
         //
         
-        let newExpense: NSManagedObject = NSEntityDescription.insertNewObjectForEntityForName("Expense", inManagedObjectContext: context!) 
+        let newExpense: NSManagedObject = NSEntityDescription.insertNewObject(forEntityName: "Expense", into: context!) 
         newExpense.setValue(expenseValue, forKey: "value")
         newExpense.setValue(expenseName, forKey: "name")
         newExpense.setValue(expenseType, forKey: "type")
@@ -100,15 +100,15 @@ class AddExpenseViewController: NSViewController {
             // Cleanup fields
             self.valueText.stringValue = ""
             self.nameText.stringValue = ""
-            self.typeText.selectItemAtIndex(0)
+            self.typeText.selectItem(at: 0)
             self.typeText.setTitle(uncategorizedStringValue)
-            self.dateText.dateValue = NSDate()
+            self.dateText.dateValue = Date()
             
             //self.mainViewController.showAlert(NSLocalizedString("Your expense was added successfully.", comment:""), window: self.view.window!)
         } else {
             NSLog("Error: %@", error!)
             
-            self.mainViewController.showAlert(NSLocalizedString("There was an error adding your expense. Please confirm the value types match.", comment:""), window: self.view.window!)
+            self.mainViewController.showAlert(NSLocalizedString("There was an error adding your expense. Please confirm the value types match.", comment:"") as NSString, window: self.view.window!)
         }
     }
 
@@ -121,11 +121,11 @@ class AddExpenseViewController: NSViewController {
         
         //
         // Update value placeholder
-        let numberFormatter = NSNumberFormatter()
-        numberFormatter.locale = NSLocale.currentLocale()
-        numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale.current
+        numberFormatter.numberStyle = NumberFormatter.Style.decimal
         
-        self.valueText.placeholderString = numberFormatter.stringFromNumber(9.99)
+        self.valueText.placeholderString = numberFormatter.string(from: 9.99)
         
         //
         // Add items to drop-down
@@ -138,18 +138,18 @@ class AddExpenseViewController: NSViewController {
         expenseTypeStrings.append( self.uncategorizedStringValue )
         
         for expenseType in self.expenseTypes {
-            expenseTypeStrings.append( expenseType.valueForKey("name") as! String )
+            expenseTypeStrings.append( (expenseType as AnyObject).value(forKey: "name") as! String )
         }
         
         self.typeText.removeAllItems()
-        self.typeText.addItemsWithTitles(expenseTypeStrings)
+        self.typeText.addItems(withTitles: expenseTypeStrings)
         
         // Select uncategorized by default
-        self.typeText.selectItemWithTitle(self.uncategorizedStringValue)
+        self.typeText.selectItem(withTitle: self.uncategorizedStringValue)
         self.typeText.setTitle(self.uncategorizedStringValue)
         
         // Set default date for today
-        self.dateText.dateValue = NSDate()
+        self.dateText.dateValue = Date()
     }
     
     override func viewWillAppear() {
@@ -157,12 +157,12 @@ class AddExpenseViewController: NSViewController {
     
     // Get all expense types
     func getAllExpenseTypes() {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let entityDesc = NSEntityDescription.entityForName("ExpenseType", inManagedObjectContext:context!)
+        let entityDesc = NSEntityDescription.entity(forEntityName: "ExpenseType", in:context!)
         
-        let request = NSFetchRequest()
+        let request = NSFetchRequest<NSFetchRequestResult>()
         request.entity = entityDesc
         
         // Sort expenses by name
@@ -178,7 +178,7 @@ class AddExpenseViewController: NSViewController {
         var objects: NSArray
         
         let error: NSError? = nil
-        objects = try! context!.executeFetchRequest(request)
+        objects = try! context!.fetch(request) as NSArray
         
         if ( error != nil ) {
             objects = []
@@ -200,7 +200,7 @@ class AddExpenseViewController: NSViewController {
     }
     
     // This is what visually updates the selected item when the popup is changed
-    @IBAction func typePopUpChanged(sender: AnyObject) {
+    @IBAction func typePopUpChanged(_ sender: AnyObject) {
         self.typeText.setTitle( self.typeText.titleOfSelectedItem! )
     }
 

--- a/Oikon/AddExpenseViewController.swift
+++ b/Oikon/AddExpenseViewController.swift
@@ -36,11 +36,24 @@ class AddExpenseViewController: NSViewController {
         var expenseType: NSString? = uncategorizedStringValue as NSString
         var expenseDate: Date = Date()// Default expense date to "now"
         
+        // Replace comma decimal to dot decimal
+        if (numberFormatter.currencyDecimalSeparator == ".") {
+            let tmpVal = self.valueText.stringValue.replacingOccurrences(of: ",", with: ".")
+            self.valueText.stringValue = tmpVal
+        }
+        
+        // Replace dot decimal to comma decimal
+        if (numberFormatter.currencyDecimalSeparator == ",") {
+            let tmpVal = self.valueText.stringValue.replacingOccurrences(of: ".", with: ",")
+            self.valueText.stringValue = tmpVal
+        }
+        
         // Avoid empty values crashing the code
         if let tmpExpenseValue: NSNumber = numberFormatter.number(from: self.valueText.stringValue) {
             expenseValue = tmpExpenseValue
         }
-        if let tmpExpenseName: NSString = self.nameText.stringValue as NSString? {
+        if let tmpExpenseName: NSString = self.nameText.stringValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+ as NSString? {
             expenseName = tmpExpenseName
         }
         if let tmpExpenseType: NSString = self.typeText.titleOfSelectedItem! as NSString? {

--- a/Oikon/AppDelegate.swift
+++ b/Oikon/AppDelegate.swift
@@ -11,55 +11,55 @@ import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDelegate {
 
-    func applicationDidFinishLaunching(aNotification: NSNotification) {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
         
         self.synchronizeSettings()
 
         // Allow sending notifications even when the app is not focused
-        NSUserNotificationCenter.defaultUserNotificationCenter().delegate = self
+        NSUserNotificationCenter.default.delegate = self
         
         // Listen for iCloud changes (when they will happen)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "iCloudWillUpdate:", name: NSPersistentStoreCoordinatorStoresWillChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(AppDelegate.iCloudWillUpdate(_:)), name: NSNotification.Name.NSPersistentStoreCoordinatorStoresWillChange, object: nil)
         
         // Listen for iCloud changes (after it's done)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "iCloudDidUpdate:", name: NSPersistentStoreCoordinatorStoresDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(AppDelegate.iCloudDidUpdate(_:)), name: NSNotification.Name.NSPersistentStoreCoordinatorStoresDidChange, object: nil)
     }
 
-    func applicationWillTerminate(aNotification: NSNotification) {
+    func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
     
-    func userNotificationCenter(center: NSUserNotificationCenter, shouldPresentNotification notification: NSUserNotification) -> Bool {
+    func userNotificationCenter(_ center: NSUserNotificationCenter, shouldPresent notification: NSUserNotification) -> Bool {
         return true
     }
 
     // MARK: - Core Data stack
 
-    lazy var applicationDocumentsDirectory: NSURL = {
+    lazy var applicationDocumentsDirectory: URL = {
         // The directory the application uses to store the Core Data store file. This code uses a directory named "com.emotionloop.OikonMac" in the user's Application Support directory.
-        let urls = NSFileManager.defaultManager().URLsForDirectory(.ApplicationSupportDirectory, inDomains: .UserDomainMask)
+        let urls = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
         let appSupportURL = urls[urls.count - 1] 
-        return appSupportURL.URLByAppendingPathComponent("com.emotionloop.OikonMac")
+        return appSupportURL.appendingPathComponent("com.emotionloop.OikonMac")
     }()
 
     lazy var managedObjectModel: NSManagedObjectModel = {
         // The managed object model for the application. This property is not optional. It is a fatal error for the application not to be able to find and load its model.
-        let modelURL = NSBundle.mainBundle().URLForResource("Oikon", withExtension: "momd")!
-        return NSManagedObjectModel(contentsOfURL: modelURL)!
+        let modelURL = Bundle.main.url(forResource: "Oikon", withExtension: "momd")!
+        return NSManagedObjectModel(contentsOf: modelURL)!
     }()
 
     lazy var persistentStoreCoordinator: NSPersistentStoreCoordinator? = {
         // The persistent store coordinator for the application. This implementation creates and return a coordinator, having added the store for the application to it. (The directory for the store is created, if necessary.) This property is optional since there are legitimate error conditions that could cause the creation of the store to fail.
-        let fileManager = NSFileManager.defaultManager()
+        let fileManager = FileManager.default
         var shouldFail = false
         var error: NSError? = nil
         var failureReason = "There was an error creating or loading the application's saved data."
 
         // Make sure the application files directory is there
-        let propertiesOpt: [NSObject: AnyObject]?
+        let propertiesOpt: [AnyHashable: Any]?
         do {
-            propertiesOpt = try self.applicationDocumentsDirectory.resourceValuesForKeys([NSURLIsDirectoryKey])
+            propertiesOpt = try (self.applicationDocumentsDirectory as NSURL).resourceValues(forKeys: [URLResourceKey.isDirectoryKey])
         } catch var error1 as NSError {
             error = error1
             propertiesOpt = nil
@@ -68,13 +68,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         }
 
         if let properties = propertiesOpt {
-            if !properties[NSURLIsDirectoryKey]!.boolValue {
+            if !(properties[URLResourceKey.isDirectoryKey]! as AnyObject).boolValue {
                 failureReason = "Expected a folder to store application data, found a file \(self.applicationDocumentsDirectory.path)."
                 shouldFail = true
             }
         } else {
             do {
-                try fileManager.createDirectoryAtPath(self.applicationDocumentsDirectory.path!, withIntermediateDirectories: true, attributes: nil)
+                try fileManager.createDirectory(atPath: self.applicationDocumentsDirectory.path, withIntermediateDirectories: true, attributes: nil)
             } catch var error1 as NSError {
                 error = error1
             } catch {
@@ -87,7 +87,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         if !shouldFail && (error == nil) {
             coordinator = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
             do {
-                try coordinator!.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: self.currentStoreURL(), options: self.storeOptions as! [NSObject : AnyObject]?)
+                try coordinator!.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: self.currentStoreURL(), options: self.storeOptions as! [AnyHashable: Any]?)
             } catch var error1 as NSError {
                 error = error1
             } catch {
@@ -108,7 +108,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
             NSLog("Error: %@", error!)
             
             do {
-                try fileManager.createDirectoryAtPath(self.applicationDocumentsDirectory.path!, withIntermediateDirectories: true, attributes: nil)
+                try fileManager.createDirectory(atPath: self.applicationDocumentsDirectory.path, withIntermediateDirectories: true, attributes: nil)
             } catch var error1 as NSError {
                 error = error1
             } catch {
@@ -117,7 +117,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
             
             coordinator = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
             do {
-                try coordinator!.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: self.currentStoreURL(), options: self.storeOptions as! [NSObject : AnyObject]?)
+                try coordinator!.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: self.currentStoreURL(), options: self.storeOptions as! [AnyHashable: Any]?)
             } catch var error1 as NSError {
                 error = error1
             } catch {
@@ -141,11 +141,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
 
     // MARK: - Core Data Saving and Undo support
 
-    @IBAction func saveAction(sender: AnyObject!) {
+    @IBAction func saveAction(_ sender: AnyObject!) {
         // Performs the save action for the application, which is to send the save: message to the application's managed object context. Any encountered errors are presented to the user.
         if let moc = self.managedObjectContext {
             if !moc.commitEditing() {
-                NSLog("\(NSStringFromClass(self.dynamicType)) unable to commit editing before saving")
+                NSLog("\(NSStringFromClass(type(of: self))) unable to commit editing before saving")
             }
             var error: NSError? = nil
             if moc.hasChanges {
@@ -161,7 +161,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         }
     }
 
-    func windowWillReturnUndoManager(window: NSWindow) -> NSUndoManager? {
+    func windowWillReturnUndoManager(_ window: NSWindow) -> UndoManager? {
         // Returns the NSUndoManager for the application. In this case, the manager returned is that of the managed object context for the application.
         if let moc = self.managedObjectContext {
             return moc.undoManager
@@ -170,17 +170,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         }
     }
 
-    func applicationShouldTerminate(sender: NSApplication) -> NSApplicationTerminateReply {
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplicationTerminateReply {
         // Save changes in the application's managed object context before the application terminates.
         
         if let moc = managedObjectContext {
             if !moc.commitEditing() {
-                NSLog("\(NSStringFromClass(self.dynamicType)) unable to commit editing to terminate")
-                return .TerminateCancel
+                NSLog("\(NSStringFromClass(type(of: self))) unable to commit editing to terminate")
+                return .terminateCancel
             }
             
             if !moc.hasChanges {
-                return .TerminateNow
+                return .terminateNow
             }
             
             var error: NSError? = nil
@@ -194,7 +194,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
             if ( error != nil ) {
                 let result = sender.presentError(error!)
                 if (result) {
-                    return .TerminateCancel
+                    return .terminateCancel
                 }
                 
                 let question = NSLocalizedString("Could not save changes while quitting. Quit anyway?", comment: "Quit without saves error question message")
@@ -204,23 +204,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
                 let alert = NSAlert()
                 alert.messageText = question
                 alert.informativeText = info
-                alert.addButtonWithTitle(quitButton)
-                alert.addButtonWithTitle(cancelButton)
+                alert.addButton(withTitle: quitButton)
+                alert.addButton(withTitle: cancelButton)
                 
                 let answer = alert.runModal()
                 if answer == NSAlertFirstButtonReturn {
-                    return .TerminateCancel
+                    return .terminateCancel
                 }
             }
         }
 
         // If we got here, it is time to quit.
-        return .TerminateNow
+        return .terminateNow
     }
     
     // Get current store URL (it will change based on if iCloud is enabled or not)
-    func currentStoreURL() -> NSURL {
-        return self.applicationDocumentsDirectory.URLByAppendingPathComponent("Oikon.sqlite")
+    func currentStoreURL() -> URL {
+        return self.applicationDocumentsDirectory.appendingPathComponent("Oikon.sqlite")
     }
     
     // Store options for iCloud
@@ -233,11 +233,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         return [ NSPersistentStoreUbiquitousContentNameKey: "localStore" ]
     }
     
-    var settings: NSUserDefaults = NSUserDefaults.standardUserDefaults()
+    var settings: UserDefaults = UserDefaults.standard
     var storeOptions: NSDictionary? = nil
     
     // Reload store
-    func reloadWithNewStore(newStore: NSPersistentStore?) {
+    func reloadWithNewStore(_ newStore: NSPersistentStore?) {
         NSLog("RELOADING STORE")
         
         self.synchronizeSettings()
@@ -246,22 +246,26 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
             var error: NSError? = nil
             
             do {
-                try self.persistentStoreCoordinator?.removePersistentStore(newStore!)
+                try self.persistentStoreCoordinator?.remove(newStore!)
             } catch let error1 as NSError {
                 error = error1
             }
             
             if ( error != nil ) {
-                NSLog("Unresolved error while removing persistent store \(error), \(error?.userInfo)")
+                NSLog("Unresolved error while removing persistent store \(String(describing: error)), \(String(describing: error?.userInfo))")
             }
         }
         
         var error: NSError? = nil
         
         do {
-            try self.persistentStoreCoordinator?.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: self.currentStoreURL(), options:self.storeOptions as! [NSObject : AnyObject]?)
+            try self.persistentStoreCoordinator?.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: self.currentStoreURL(), options:self.storeOptions as! [AnyHashable: Any]?)
         } catch let error1 as NSError {
             error = error1
+            
+            if ( error != nil ) {
+                NSLog("Unresolved error while adding persistent store \(String(describing: error)), \(String(describing: error?.userInfo))")
+            }
         }
     }
 
@@ -269,11 +273,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     func synchronizeSettings() -> Void {
         NSLog( "## Starting settings synchronization ##" )
 
-        self.settings = NSUserDefaults.standardUserDefaults()
+        self.settings = UserDefaults.standard
         self.settings.synchronize()
         
         // iCloud sync
-        if ( self.settings.objectForKey("iCloud.osx") == nil ) {
+        if ( self.settings.object(forKey: "iCloud.osx") == nil ) {
             let defaultiCloud: NSMutableDictionary = [:]
             
             defaultiCloud.setValue(false, forKey:"isEnabled")
@@ -282,16 +286,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
             defaultiCloud.setValue(nil, forKey:"lastRemoteSync")// Last time an update existed remotely
             defaultiCloud.setValue(nil, forKey:"lastLocalUpdate")// Last time something was updated locally
             
-            self.settings.setObject(defaultiCloud, forKey: "iCloud.osx")
+            self.settings.set(defaultiCloud, forKey: "iCloud.osx")
             
             NSLog("#!## LOADING LOCAL DATA ##!#")
             self.storeOptions = self.localStoreOptions()
         } else {
             var iCloudSettings: NSMutableDictionary
             
-            iCloudSettings = self.settings.objectForKey("iCloud.osx") as! NSMutableDictionary
+            iCloudSettings = self.settings.object(forKey: "iCloud.osx") as! NSMutableDictionary
             
-            if ( iCloudSettings.valueForKey("isEnabled") as! Bool == true ) {
+            if ( iCloudSettings.value(forKey: "isEnabled") as! Bool == true ) {
                 NSLog("### LOADING ICLOUD DATA ###")
                 self.storeOptions = self.iCloudStoreOptions()
             } else {
@@ -301,57 +305,57 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         }
         
         // Search dates
-        if ( self.settings.valueForKey("searchFromDate.osx") == nil ) {
+        if ( self.settings.value(forKey: "searchFromDate.osx") == nil ) {
             self.settings.setValue(nil, forKey:"searchFromDate.osx")
         }
         
-        if ( self.settings.valueForKey("searchToDate.osx") == nil ) {
+        if ( self.settings.value(forKey: "searchToDate.osx") == nil ) {
             self.settings.setValue(nil, forKey:"searchToDate.osx")
         }
         
         // Filters - Type
-        if ( self.settings.valueForKey("filterTypes.osx") == nil ) {
+        if ( self.settings.value(forKey: "filterTypes.osx") == nil ) {
             self.settings.setValue(nil, forKey:"filterTypes.osx")
         }
         
         // Filters - Name
-        if ( self.settings.valueForKey("filterName.osx") == nil ) {
+        if ( self.settings.value(forKey: "filterName.osx") == nil ) {
             self.settings.setValue(nil, forKey:"filterName.osx")
         }
         
         self.settings.synchronize()
     }
     
-    @IBAction func iCloudWillUpdate( sender: AnyObject? ) {
+    @IBAction func iCloudWillUpdate( _ sender: AnyObject? ) {
         self.setiCloudStartSyncDate()
     }
     
-    @IBAction func iCloudDidUpdate( sender: AnyObject? ) {
+    @IBAction func iCloudDidUpdate( _ sender: AnyObject? ) {
         self.setiCloudEndSyncDate()
     }
     
     // Update iCloud start sync date
     func setiCloudStartSyncDate() {
-        let iCloudSettings: NSMutableDictionary = self.settings.objectForKey("iCloud.osx")?.mutableCopy() as! NSMutableDictionary
+        let iCloudSettings: NSMutableDictionary = (self.settings.object(forKey: "iCloud.osx") as! NSDictionary!).mutableCopy() as! NSMutableDictionary
     
         print("Set the sync start date to now", terminator: "")
     
         // Set the sync start date to now
-        iCloudSettings.setValue(NSDate(), forKey:"lastSyncStart")
+        iCloudSettings.setValue(Date(), forKey:"lastSyncStart")
     
-        self.settings.setObject(iCloudSettings, forKey:"iCloud.osx")
+        self.settings.set(iCloudSettings, forKey:"iCloud.osx")
     }
     
     // Update iCloud end sync date
     func setiCloudEndSyncDate() {
-        let iCloudSettings: NSMutableDictionary = self.settings.objectForKey("iCloud.osx")?.mutableCopy() as! NSMutableDictionary
+        let iCloudSettings: NSMutableDictionary = (self.settings.object(forKey: "iCloud.osx") as! NSDictionary!).mutableCopy() as! NSMutableDictionary
     
         print("Set the sync end date to now", terminator: "")
     
         // Set the sync end date to now
-        iCloudSettings.setValue(NSDate(), forKey:"lastSuccessfulSync")
+        iCloudSettings.setValue(Date(), forKey:"lastSuccessfulSync")
     
-        self.settings.setObject(iCloudSettings, forKey:"iCloud.osx")
+        self.settings.set(iCloudSettings, forKey:"iCloud.osx")
     }
     
     // Migrate data to iCloud
@@ -360,7 +364,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     
         let tmpStoreOptions: NSMutableDictionary? = self.storeOptions?.mutableCopy() as! NSMutableDictionary?
     
-        tmpStoreOptions?.setObject(true, forKey:NSPersistentStoreRemoveUbiquitousMetadataOption)
+        tmpStoreOptions?.setObject(true, forKey:NSPersistentStoreRemoveUbiquitousMetadataOption as NSCopying)
     
         let tmpStore: NSPersistentStore? = nil
     
@@ -370,14 +374,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         // Reload store
         self.reloadWithNewStore(tmpStore)
     
-        let iCloudSettings: NSMutableDictionary = self.settings.objectForKey("iCloud.osx")!.mutableCopy() as! NSMutableDictionary
+        let iCloudSettings: NSMutableDictionary = (self.settings.object(forKey: "iCloud.osx") as! NSDictionary!).mutableCopy() as! NSMutableDictionary
     
         print("Set the last remote sync date to now", terminator: "")
     
         // Set the last remote sync date to now
-        iCloudSettings.setValue(NSDate(), forKey:"lastRemoteSync")
+        iCloudSettings.setValue(Date(), forKey:"lastRemoteSync")
     
-        self.settings.setObject(iCloudSettings, forKey:"iCloud.osx")
+        self.settings.set(iCloudSettings, forKey:"iCloud.osx")
     }
     
     // Migrate data to Local
@@ -386,7 +390,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     
         let tmpStoreOptions: NSMutableDictionary? = self.storeOptions?.mutableCopy() as! NSMutableDictionary?
     
-        tmpStoreOptions?.setObject(true, forKey:NSPersistentStoreRemoveUbiquitousMetadataOption)
+        tmpStoreOptions?.setObject(true, forKey:NSPersistentStoreRemoveUbiquitousMetadataOption as NSCopying)
     
         let tmpStore: NSPersistentStore? = nil
         
@@ -396,38 +400,38 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         // Reload store
         self.reloadWithNewStore(tmpStore)
         
-        let iCloudSettings: NSMutableDictionary = self.settings.objectForKey("iCloud.osx")?.mutableCopy() as! NSMutableDictionary
+        let iCloudSettings: NSMutableDictionary = (self.settings.object(forKey: "iCloud.osx") as! NSDictionary!).mutableCopy() as! NSMutableDictionary
     
         print("Set the last local sync date to now", terminator: "")
     
         // Set the last local sync date to now
-        iCloudSettings.setValue(NSDate(), forKey:"lastLocalUpdate")
+        iCloudSettings.setValue(Date(), forKey:"lastLocalUpdate")
     
-        self.settings.setObject(iCloudSettings, forKey:"iCloud.osx")
+        self.settings.set(iCloudSettings, forKey:"iCloud.osx")
     }
     
     // Remove all data
     func removeAllData() {
         print("REMOVING ALL DATA!", terminator: "")
     
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
     
         // Remove all expenses
-        var entityDesc = NSEntityDescription.entityForName("Expense", inManagedObjectContext:context!)
+        var entityDesc = NSEntityDescription.entity(forEntityName: "Expense", in:context!)
         
-        var request = NSFetchRequest()
+        var request = NSFetchRequest<NSFetchRequestResult>()
         request.entity = entityDesc
         
         var objects: [NSManagedObject]
         
         var error: NSError? = nil
         
-        objects = (try! context!.executeFetchRequest(request)) as! [NSManagedObject]
+        objects = (try! context!.fetch(request)) as! [NSManagedObject]
         
         if ( error == nil ) {
             for object: NSManagedObject in objects {
-                context?.deleteObject(object)
+                context?.delete(object)
             }
             
             do {
@@ -440,18 +444,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         }
         
         // Remove all expense types
-        entityDesc = NSEntityDescription.entityForName("ExpenseType", inManagedObjectContext:context!)
+        entityDesc = NSEntityDescription.entity(forEntityName: "ExpenseType", in:context!)
         
         request = NSFetchRequest()
         request.entity = entityDesc
         
         objects = []
         
-        (try! context!.executeFetchRequest(request)) as! [NSManagedObject]
+        (try! context!.fetch(request)) as! [NSManagedObject]
         
         if ( error == nil ) {
             for object: NSManagedObject in objects {
-                context?.deleteObject(object)
+                context?.delete(object)
             }
             
             do {

--- a/Oikon/Base.lproj/Main.storyboard
+++ b/Oikon/Base.lproj/Main.storyboard
@@ -490,8 +490,8 @@
                                 </connections>
                             </button>
                             <button ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7dz-nQ-PMC">
-                                <rect key="frame" x="18" y="199" width="103" height="23"/>
-                                <buttonCell key="cell" type="check" title="iCloud Sync" bezelStyle="regularSquare" imagePosition="left" lineBreakMode="truncatingMiddle" inset="2" id="Seu-JJ-Thi">
+                                <rect key="frame" x="18" y="199" width="113" height="23"/>
+                                <buttonCell key="cell" type="check" title="iCloud Sync" bezelStyle="regularSquare" imagePosition="left" alignment="center" lineBreakMode="truncatingMiddle" imageScaling="proportionallyUpOrDown" inset="2" id="Seu-JJ-Thi">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" size="16" name="HelveticaNeue-Thin"/>
                                 </buttonCell>
@@ -502,7 +502,7 @@
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="veY-Nr-TwT" secondAttribute="bottom" constant="20" id="0WA-DT-ick"/>
-                            <constraint firstAttribute="trailing" secondItem="7dz-nQ-PMC" secondAttribute="trailing" constant="57" id="EXW-EH-DOb"/>
+                            <constraint firstAttribute="trailing" secondItem="7dz-nQ-PMC" secondAttribute="trailing" constant="47" id="EXW-EH-DOb"/>
                             <constraint firstAttribute="trailing" secondItem="qL9-k5-5i9" secondAttribute="trailing" constant="20" id="HRQ-gW-6tX"/>
                             <constraint firstAttribute="trailing" secondItem="veY-Nr-TwT" secondAttribute="trailing" constant="26" id="Md1-dR-pVH"/>
                             <constraint firstAttribute="trailing" secondItem="6FI-vM-eWn" secondAttribute="trailing" constant="93" id="O6F-ra-xsO"/>
@@ -583,14 +583,14 @@
                             <box horizontalHuggingPriority="750" ambiguous="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="oLk-hN-agE">
                                 <rect key="frame" x="211" y="236" width="5" height="194"/>
                             </box>
-                            <scrollView misplaced="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="23" horizontalPageScroll="10" verticalLineScroll="23" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nuw-B2-l9i">
-                                <rect key="frame" x="0.0" y="0.0" width="450" height="239"/>
+                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="23" horizontalPageScroll="10" verticalLineScroll="23" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nuw-B2-l9i">
+                                <rect key="frame" x="0.0" y="0.0" width="450" height="247"/>
                                 <clipView key="contentView" id="XaS-Jx-uXY">
-                                    <rect key="frame" x="0.0" y="0.0" width="450" height="239"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="450" height="247"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="21" headerView="ikZ-Ha-F7g" viewBased="YES" id="4OW-yt-24y">
-                                            <rect key="frame" x="0.0" y="0.0" width="450" height="216"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="450" height="224"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -611,10 +611,10 @@
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="nameCell" id="qHx-ZN-FK9">
                                                             <rect key="frame" x="1" y="1" width="171" height="17"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0YJ-ah-QhX">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="170" height="20"/>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0YJ-ah-QhX">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="171" height="20"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="coffee" id="JEt-gG-F89">
                                                                         <font key="font" size="13" name="HelveticaNeue-Light"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -647,10 +647,10 @@
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="typeCell" id="Wls-u9-OB2">
                                                             <rect key="frame" x="175.5" y="1" width="122" height="17"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ryZ-n8-Uzx">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="121" height="20"/>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ryZ-n8-Uzx">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="122" height="20"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="—" id="z0I-7t-2TW">
                                                                         <font key="font" size="13" name="HelveticaNeue-Light"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -683,10 +683,10 @@
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="dateCell" id="7Sh-58-wXs">
                                                             <rect key="frame" x="301" y="1" width="93" height="17"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="flk-XV-IvD">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="92" height="20"/>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="flk-XV-IvD">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="93" height="20"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="Feb 1" id="ikh-aq-GOH">
                                                                         <font key="font" size="13" name="HelveticaNeue-Light"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -719,7 +719,7 @@
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="valueCell" id="Eet-aI-AKw">
                                                             <rect key="frame" x="397" y="1" width="50" height="17"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zLs-dM-Usb">
                                                                     <rect key="frame" x="0.0" y="0.0" width="50" height="20"/>
@@ -944,34 +944,34 @@
                         <rect key="frame" x="0.0" y="0.0" width="275" height="300"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="chf-0y-Acj">
-                                <rect key="frame" x="85" y="201" width="104" height="29"/>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="chf-0y-Acj">
+                                <rect key="frame" x="85" y="198" width="104" height="29"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Total" id="qgE-jz-8ZC">
                                     <font key="font" size="24" name="HelveticaNeue-Light"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OAs-0s-5o8">
-                                <rect key="frame" x="90" y="114" width="94" height="17"/>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OAs-0s-5o8">
+                                <rect key="frame" x="90" y="111" width="94" height="17"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="BY CATEGORY" id="xna-1u-7qj">
                                     <font key="font" size="11" name="HelveticaNeue-Light"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmq-Fp-SYM">
-                                <rect key="frame" x="18" y="155" width="239" height="36"/>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmq-Fp-SYM">
+                                <rect key="frame" x="18" y="152" width="239" height="36"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" title="3767.25" id="W0p-kq-qbY">
                                     <font key="font" size="30" name="HelveticaNeue-Light"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <searchField wantsLayer="YES" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E8a-Zi-0F7">
-                                <rect key="frame" x="55" y="258" width="165" height="20"/>
-                                <searchFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Filter Expenses" drawsBackground="YES" usesSingleLineMode="YES" id="hIP-6f-ObS">
-                                    <font key="font" size="13" name="HelveticaNeue-Light"/>
+                            <searchField wantsLayer="YES" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E8a-Zi-0F7">
+                                <rect key="frame" x="55" y="257" width="165" height="23"/>
+                                <searchFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" placeholderString="Filter Expenses" drawsBackground="YES" usesSingleLineMode="YES" id="hIP-6f-ObS">
+                                    <font key="font" metaFont="system" size="14"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </searchFieldCell>
@@ -979,14 +979,14 @@
                                     <action selector="enteredSearchText:" target="2eo-YP-dCz" id="SsM-sA-GhB"/>
                                 </connections>
                             </searchField>
-                            <scrollView ambiguous="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="25" horizontalPageScroll="10" verticalLineScroll="25" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ic1-Yg-dmq">
-                                <rect key="frame" x="20" y="20" width="235" height="86"/>
-                                <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="Fqc-jL-Vwo">
-                                    <rect key="frame" x="0.0" y="0.0" width="235" height="86"/>
+                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="25" horizontalPageScroll="10" verticalLineScroll="25" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ic1-Yg-dmq">
+                                <rect key="frame" x="20" y="20" width="235" height="83"/>
+                                <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="Fqc-jL-Vwo">
+                                    <rect key="frame" x="0.0" y="0.0" width="235" height="83"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" selectionHighlightStyle="none" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="25" viewBased="YES" id="CxY-2v-M5G">
-                                            <rect key="frame" x="0.0" y="0.0" width="235" height="86"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="235" height="83"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                             <color key="gridColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
@@ -1079,7 +1079,7 @@
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="28" id="bE8-37-0Kc">
                                                                         <font key="font" size="13" name="HelveticaNeue-Thin"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
                                                             </subviews>
@@ -1105,10 +1105,13 @@
                             </scrollView>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="vmq-Fp-SYM" firstAttribute="top" secondItem="chf-0y-Acj" secondAttribute="bottom" constant="10" id="1ar-OQ-czk"/>
                             <constraint firstItem="ic1-Yg-dmq" firstAttribute="top" secondItem="OAs-0s-5o8" secondAttribute="bottom" constant="8" id="3ew-Nd-J4P"/>
+                            <constraint firstItem="OAs-0s-5o8" firstAttribute="top" secondItem="vmq-Fp-SYM" secondAttribute="bottom" constant="24" id="6QS-qY-whh"/>
+                            <constraint firstItem="E8a-Zi-0F7" firstAttribute="top" secondItem="Qnj-cP-ZP7" secondAttribute="top" constant="20" id="AHv-HI-mCZ"/>
                             <constraint firstItem="vmq-Fp-SYM" firstAttribute="leading" secondItem="Qnj-cP-ZP7" secondAttribute="leading" constant="20" id="BYj-Uu-q0l"/>
+                            <constraint firstItem="ic1-Yg-dmq" firstAttribute="top" secondItem="OAs-0s-5o8" secondAttribute="bottom" constant="8" id="HnQ-gM-gX3"/>
                             <constraint firstItem="chf-0y-Acj" firstAttribute="leading" secondItem="Qnj-cP-ZP7" secondAttribute="leading" constant="87" id="PpZ-Bg-qP7"/>
-                            <constraint firstItem="E8a-Zi-0F7" firstAttribute="top" secondItem="Qnj-cP-ZP7" secondAttribute="top" constant="20" id="cEY-vx-X2p"/>
                             <constraint firstAttribute="trailing" secondItem="OAs-0s-5o8" secondAttribute="trailing" constant="93" id="g31-Qf-kS8"/>
                             <constraint firstItem="E8a-Zi-0F7" firstAttribute="leading" secondItem="Qnj-cP-ZP7" secondAttribute="leading" constant="55" id="l8c-wV-S7O"/>
                             <constraint firstAttribute="trailing" secondItem="E8a-Zi-0F7" secondAttribute="trailing" constant="55" id="mDI-vn-hdo"/>
@@ -1116,6 +1119,7 @@
                             <constraint firstAttribute="bottom" secondItem="ic1-Yg-dmq" secondAttribute="bottom" constant="20" id="nhT-eS-Rws"/>
                             <constraint firstAttribute="trailing" secondItem="chf-0y-Acj" secondAttribute="trailing" constant="88" id="oYb-mj-6g6"/>
                             <constraint firstAttribute="trailing" secondItem="ic1-Yg-dmq" secondAttribute="trailing" constant="20" id="rJN-FY-aIS"/>
+                            <constraint firstItem="chf-0y-Acj" firstAttribute="top" secondItem="E8a-Zi-0F7" secondAttribute="bottom" constant="30" id="ukW-bV-hbG"/>
                             <constraint firstAttribute="trailing" secondItem="vmq-Fp-SYM" secondAttribute="trailing" constant="20" id="vI0-Mi-DYq"/>
                             <constraint firstItem="ic1-Yg-dmq" firstAttribute="leading" secondItem="Qnj-cP-ZP7" secondAttribute="leading" constant="20" id="vqF-oM-TF8"/>
                         </constraints>

--- a/Oikon/Base.lproj/Main.storyboard
+++ b/Oikon/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8152.3" systemVersion="15A215h" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8152.3"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12118"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -124,14 +125,16 @@
         <scene sceneID="hIz-AP-VOD">
             <objects>
                 <viewController title="Oikon" showSeguePresentationStyle="single" id="XfG-lQ-9wD" customClass="ViewController" customModule="Oikon" customModuleProvider="target" sceneMemberID="viewController">
-                    <visualEffectView key="view" appearanceType="vibrantDark" blendingMode="behindWindow" state="followsWindowActiveState" id="12f-OC-8cl">
+                    <visualEffectView key="view" appearanceType="vibrantDark" blendingMode="behindWindow" material="appearanceBased" state="followsWindowActiveState" id="12f-OC-8cl">
                         <rect key="frame" x="0.0" y="0.0" width="300" height="405"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <subviews>
-                            <button ambiguous="YES" misplaced="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="JMO-Bd-kdK">
-                                <rect key="frame" x="20" y="188" width="130" height="100"/>
-                                <animations/>
-                                <buttonCell key="cell" type="square" title="Add Expense" bezelStyle="shadowlessSquare" imagePosition="above" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="IpS-xL-F5j">
+                            <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="JMO-Bd-kdK">
+                                <rect key="frame" x="20" y="188" width="130" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="130" id="sfd-z7-u9C"/>
+                                </constraints>
+                                <buttonCell key="cell" type="square" title="Add Expense" bezelStyle="shadowlessSquare" imagePosition="overlaps" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="IpS-xL-F5j">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <string key="keyEquivalent">a</string>
@@ -140,10 +143,12 @@
                                     <segue destination="vAb-TZ-zjr" kind="modal" identifier="addExpense" id="xJn-Gg-vM9"/>
                                 </connections>
                             </button>
-                            <button ambiguous="YES" misplaced="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="SXY-rz-dui">
-                                <rect key="frame" x="150" y="188" width="130" height="100"/>
-                                <animations/>
-                                <buttonCell key="cell" type="square" title="Expense Types" bezelStyle="shadowlessSquare" imagePosition="above" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="dlZ-nI-ueU">
+                            <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="SXY-rz-dui">
+                                <rect key="frame" x="150" y="188" width="130" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="130" id="ewV-BE-kHY"/>
+                                </constraints>
+                                <buttonCell key="cell" type="square" title="Expense Types" bezelStyle="shadowlessSquare" imagePosition="overlaps" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="dlZ-nI-ueU">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <string key="keyEquivalent">e</string>
@@ -152,10 +157,12 @@
                                     <segue destination="bVk-Xf-EYe" kind="modal" identifier="expenseTypes" id="5g6-nq-qdT"/>
                                 </connections>
                             </button>
-                            <button ambiguous="YES" misplaced="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="9ZJ-Mg-YS0">
-                                <rect key="frame" x="20" y="89" width="130" height="100"/>
-                                <animations/>
-                                <buttonCell key="cell" type="square" title="Past Expenses" bezelStyle="shadowlessSquare" imagePosition="above" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="ufT-p3-4pL">
+                            <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="9ZJ-Mg-YS0">
+                                <rect key="frame" x="20" y="89" width="130" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="130" id="VIR-1Q-3Wa"/>
+                                </constraints>
+                                <buttonCell key="cell" type="square" title="Past Expenses" bezelStyle="shadowlessSquare" imagePosition="overlaps" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="ufT-p3-4pL">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <string key="keyEquivalent">p</string>
@@ -164,10 +171,12 @@
                                     <segue destination="ji4-DL-0YU" kind="modal" identifier="pastExpensesOpen" id="Ik5-Yt-d6d"/>
                                 </connections>
                             </button>
-                            <button ambiguous="YES" misplaced="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="5FH-c7-YFT">
-                                <rect key="frame" x="150" y="89" width="130" height="100"/>
-                                <animations/>
-                                <buttonCell key="cell" type="square" title="Settings" bezelStyle="shadowlessSquare" imagePosition="above" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="2pf-SN-hvF">
+                            <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="5FH-c7-YFT">
+                                <rect key="frame" x="150" y="89" width="130" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="130" id="69Y-8l-7K4"/>
+                                </constraints>
+                                <buttonCell key="cell" type="square" title="Settings" bezelStyle="shadowlessSquare" imagePosition="overlaps" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="2pf-SN-hvF">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <string key="keyEquivalent">s</string>
@@ -176,9 +185,8 @@
                                     <segue destination="wOn-k1-nU6" kind="modal" identifier="settings" id="cAv-bS-gHA"/>
                                 </connections>
                             </button>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ml8-XT-zyf">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ml8-XT-zyf">
                                 <rect key="frame" x="18" y="326" width="264" height="29"/>
-                                <animations/>
                                 <textFieldCell key="cell" lineBreakMode="charWrapping" sendsActionOnEndEditing="YES" alignment="center" title="Oikon" id="TtS-TE-azT">
                                     <font key="font" size="24" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -187,17 +195,18 @@
                             </textField>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="SXY-rz-dui" secondAttribute="trailing" constant="20" id="0VN-fB-8sP"/>
-                            <constraint firstItem="JMO-Bd-kdK" firstAttribute="leading" secondItem="12f-OC-8cl" secondAttribute="leading" constant="20" id="7Nl-nC-Hlb"/>
-                            <constraint firstAttribute="trailing" secondItem="5FH-c7-YFT" secondAttribute="trailing" constant="20" id="Q33-Q8-11y"/>
-                            <constraint firstItem="5FH-c7-YFT" firstAttribute="leading" secondItem="9ZJ-Mg-YS0" secondAttribute="trailing" id="QUt-KE-z6p"/>
+                            <constraint firstAttribute="bottom" secondItem="5FH-c7-YFT" secondAttribute="bottom" constant="89" id="FaS-Uf-spJ"/>
+                            <constraint firstAttribute="trailing" secondItem="5FH-c7-YFT" secondAttribute="trailing" constant="20" id="Km8-Ny-xSa"/>
+                            <constraint firstAttribute="trailing" secondItem="SXY-rz-dui" secondAttribute="trailing" constant="20" id="MPt-5Z-Nya"/>
+                            <constraint firstItem="JMO-Bd-kdK" firstAttribute="leading" secondItem="12f-OC-8cl" secondAttribute="leading" constant="20" id="Oj8-cA-V6i"/>
+                            <constraint firstItem="5FH-c7-YFT" firstAttribute="top" secondItem="SXY-rz-dui" secondAttribute="bottom" constant="78" id="PS9-nk-yP8"/>
                             <constraint firstItem="ml8-XT-zyf" firstAttribute="top" secondItem="12f-OC-8cl" secondAttribute="top" constant="50" id="Qeg-Ot-9Wh"/>
-                            <constraint firstItem="9ZJ-Mg-YS0" firstAttribute="leading" secondItem="12f-OC-8cl" secondAttribute="leading" constant="20" id="aSL-Rj-IX0"/>
+                            <constraint firstItem="9ZJ-Mg-YS0" firstAttribute="top" secondItem="JMO-Bd-kdK" secondAttribute="bottom" constant="78" id="ZMi-d0-zmI"/>
+                            <constraint firstAttribute="bottom" secondItem="9ZJ-Mg-YS0" secondAttribute="bottom" constant="89" id="ah3-q4-cvW"/>
                             <constraint firstAttribute="trailing" secondItem="ml8-XT-zyf" secondAttribute="trailing" constant="20" id="b1V-Bw-rKX"/>
-                            <constraint firstItem="SXY-rz-dui" firstAttribute="leading" secondItem="JMO-Bd-kdK" secondAttribute="trailing" id="bVf-dL-CQK"/>
+                            <constraint firstItem="9ZJ-Mg-YS0" firstAttribute="leading" secondItem="12f-OC-8cl" secondAttribute="leading" constant="20" id="f2V-Ya-ueK"/>
                             <constraint firstItem="ml8-XT-zyf" firstAttribute="leading" secondItem="12f-OC-8cl" secondAttribute="leading" constant="20" id="kKE-vJ-Msm"/>
                         </constraints>
-                        <animations/>
                     </visualEffectView>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -221,7 +230,6 @@
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" headerView="8qV-tU-We6" viewBased="YES" id="UgY-wW-Yvx">
                                             <rect key="frame" x="0.0" y="0.0" width="365" height="247"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                            <animations/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -243,9 +251,9 @@
                                                             <rect key="frame" x="1" y="1" width="255" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LDE-7r-Lby">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LDE-7r-Lby">
                                                                     <rect key="frame" x="0.0" y="0.0" width="100" height="20"/>
-                                                                    <animations/>
+                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="left" title="uncategorized" id="GqO-3i-osi">
                                                                         <font key="font" size="13" name="HelveticaNeue-Thin"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -253,7 +261,6 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                             </subviews>
-                                                            <animations/>
                                                             <connections>
                                                                 <outlet property="textField" destination="LDE-7r-Lby" id="IMy-L0-uRX"/>
                                                             </connections>
@@ -277,9 +284,9 @@
                                                             <rect key="frame" x="259" y="1" width="104" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GOO-mq-ssF">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GOO-mq-ssF">
                                                                     <rect key="frame" x="0.0" y="0.0" width="100" height="17"/>
-                                                                    <animations/>
+                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" title="5" id="8fm-ON-odT">
                                                                         <font key="font" size="13" name="HelveticaNeue-Thin"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -287,7 +294,6 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                             </subviews>
-                                                            <animations/>
                                                             <connections>
                                                                 <outlet property="textField" destination="GOO-mq-ssF" id="yTL-rt-D3Y"/>
                                                             </connections>
@@ -300,29 +306,24 @@
                                             </connections>
                                         </tableView>
                                     </subviews>
-                                    <animations/>
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                 </clipView>
-                                <animations/>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="FOf-Ge-QcL">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="FOf-Ge-QcL">
                                     <rect key="frame" x="1" y="119" width="223" height="15"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="Un7-H9-S7d">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="Un7-H9-S7d">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </scroller>
                                 <tableHeaderView key="headerView" id="8qV-tU-We6">
                                     <rect key="frame" x="0.0" y="0.0" width="365" height="23"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </tableHeaderView>
                             </scrollView>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="R3C-oC-iSH">
                                 <rect key="frame" x="97" y="268" width="170" height="33"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="bevel" title="Add Expense Type" bezelStyle="regularSquare" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Y8U-Dg-goU">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="14" name="HelveticaNeue-Light"/>
@@ -339,7 +340,6 @@
                             <constraint firstAttribute="bottom" secondItem="yGH-l5-dBr" secondAttribute="bottom" id="joB-Rs-twK"/>
                             <constraint firstItem="yGH-l5-dBr" firstAttribute="top" secondItem="ksU-By-538" secondAttribute="top" constant="30" id="uTM-lX-nln"/>
                         </constraints>
-                        <animations/>
                     </view>
                     <connections>
                         <outlet property="expenseTypesTableView" destination="UgY-wW-Yvx" id="7GC-ab-MoW"/>
@@ -358,18 +358,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="265" height="152"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CSU-t8-5zX">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CSU-t8-5zX">
                                 <rect key="frame" x="61" y="103" width="142" height="29"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" title="Expense Type Name" id="6M9-Ez-3nS">
                                     <font key="font" size="16" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dOy-h9-fvg">
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dOy-h9-fvg">
                                 <rect key="frame" x="20" y="67" width="225" height="28"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" alignment="center" placeholderString="Car" drawsBackground="YES" id="kCf-K8-DNf">
                                     <font key="font" size="16" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -378,7 +378,7 @@
                             </textField>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGZ-WW-mVR">
                                 <rect key="frame" x="53" y="17" width="159" height="35"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="bevel" title="Add Expense Type" bezelStyle="regularSquare" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="uhF-OB-X0l">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="15" name="HelveticaNeue-Thin"/>
@@ -388,7 +388,6 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
                     </view>
                     <connections>
                         <outlet property="nameText" destination="dOy-h9-fvg" id="Htr-Am-JLH"/>
@@ -406,18 +405,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="265" height="143"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zNP-WJ-5mB">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zNP-WJ-5mB">
                                 <rect key="frame" x="18" y="100" width="229" height="23"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Expense Type Name" id="MTe-Re-tq3">
                                     <font key="font" size="16" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mca-9A-ebl">
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mca-9A-ebl">
                                 <rect key="frame" x="20" y="64" width="225" height="28"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" alignment="center" placeholderString="Car" drawsBackground="YES" id="QEQ-UM-IaS">
                                     <font key="font" size="16" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -426,7 +425,7 @@
                             </textField>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SBr-pP-lc1">
                                 <rect key="frame" x="14" y="17" width="117" height="35"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="bevel" title="Update" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Cbn-kY-oZU">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="15" name="HelveticaNeue-Thin"/>
@@ -437,7 +436,7 @@
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vH2-ab-0AB">
                                 <rect key="frame" x="130" y="17" width="117" height="35"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="bevel" title="Delete" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ShP-Po-grA">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="15" name="HelveticaNeue-Thin"/>
@@ -447,7 +446,6 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
                     </view>
                     <connections>
                         <outlet property="nameText" destination="mca-9A-ebl" id="ttc-dO-HqJ"/>
@@ -465,18 +463,16 @@
                         <rect key="frame" x="0.0" y="0.0" width="176" height="240"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6FI-vM-eWn">
-                                <rect key="frame" x="18" y="123" width="67" height="26"/>
-                                <animations/>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6FI-vM-eWn">
+                                <rect key="frame" x="18" y="123" width="67" height="20"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Last sync:" id="Luq-Ul-Oln">
                                     <font key="font" size="13" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qL9-k5-5i9">
-                                <rect key="frame" x="18" y="89" width="140" height="26"/>
-                                <animations/>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qL9-k5-5i9">
+                                <rect key="frame" x="18" y="89" width="140" height="20"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" alignment="right" title="just now" id="hvl-wp-GPq">
                                     <font key="font" size="13" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -485,7 +481,6 @@
                             </textField>
                             <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="veY-Nr-TwT">
                                 <rect key="frame" x="25" y="17" width="127" height="37"/>
-                                <animations/>
                                 <buttonCell key="cell" type="bevel" title="Remove All Data" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="87s-1N-Ztq">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
@@ -494,9 +489,8 @@
                                     <action selector="removeAllData:" target="wOn-k1-nU6" id="kcb-IJ-hWw"/>
                                 </connections>
                             </button>
-                            <button ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7dz-nQ-PMC">
+                            <button ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7dz-nQ-PMC">
                                 <rect key="frame" x="18" y="199" width="103" height="23"/>
-                                <animations/>
                                 <buttonCell key="cell" type="check" title="iCloud Sync" bezelStyle="regularSquare" imagePosition="left" lineBreakMode="truncatingMiddle" inset="2" id="Seu-JJ-Thi">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" size="16" name="HelveticaNeue-Thin"/>
@@ -517,7 +511,6 @@
                             <constraint firstItem="qL9-k5-5i9" firstAttribute="leading" secondItem="29j-o2-o67" secondAttribute="leading" constant="20" id="iAX-yK-Pqo"/>
                             <constraint firstItem="7dz-nQ-PMC" firstAttribute="leading" secondItem="29j-o2-o67" secondAttribute="leading" constant="20" id="jDP-3h-bqH"/>
                         </constraints>
-                        <animations/>
                     </view>
                     <connections>
                         <outlet property="iCloudSwitch" destination="7dz-nQ-PMC" id="iCO-WO-tF2"/>
@@ -539,7 +532,6 @@
                     <splitView key="splitView" dividerStyle="thin" vertical="YES" id="6HX-ik-lzf">
                         <rect key="frame" x="0.0" y="0.0" width="725" height="437"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </splitView>
                     <connections>
                         <segue destination="Osp-Fn-XcN" kind="relationship" relationship="splitItems" id="L5b-JU-eVp"/>
@@ -558,24 +550,21 @@
                         <rect key="frame" x="0.0" y="0.0" width="450" height="430"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="V2b-ad-fx5">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V2b-ad-fx5">
                                 <rect key="frame" x="11" y="403" width="40" height="17"/>
-                                <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="From:" id="fnH-CE-rEq">
                                     <font key="font" size="12" name="HelveticaNeue-Light"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <datePicker toolTip="Start date for filtering expenses" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Cob-II-8Qi">
+                            <datePicker toolTip="Start date for filtering expenses" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Cob-II-8Qi">
                                 <rect key="frame" x="57" y="266" width="139" height="148"/>
-                                <animations/>
                                 <datePickerCell key="cell" lineBreakMode="truncatingMiddle" borderStyle="bezel" alignment="left" datePickerStyle="clockAndCalendar" id="2s2-cP-m3z">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
-                                    <calendarDate key="date" timeIntervalSinceReferenceDate="-595929600" calendarFormat="%Y-%m-%d %H:%M:%S %z">
-                                        <!--1982-02-12 08:00:00 -0800-->
-                                        <timeZone key="timeZone" name="US/Pacific"/>
-                                    </calendarDate>
+                                    <date key="date" timeIntervalSinceReferenceDate="-595929600">
+                                        <!--1982-02-12 16:00:00 +0000-->
+                                    </date>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 </datePickerCell>
@@ -583,21 +572,16 @@
                                     <action selector="changedFromDate:" target="Osp-Fn-XcN" id="rde-U1-Asw"/>
                                 </connections>
                             </datePicker>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZJF-tQ-fDs">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZJF-tQ-fDs">
                                 <rect key="frame" x="238" y="403" width="40" height="19"/>
-                                <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="To:" id="zWQ-Hh-3Td">
                                     <font key="font" size="12" name="HelveticaNeue-Light"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <box horizontalHuggingPriority="750" ambiguous="YES" misplaced="YES" title="Box" boxType="separator" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="oLk-hN-agE">
-                                <rect key="frame" x="211" y="236" width="30" height="194"/>
-                                <animations/>
-                                <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                                <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                <font key="titleFont" metaFont="system"/>
+                            <box horizontalHuggingPriority="750" ambiguous="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="oLk-hN-agE">
+                                <rect key="frame" x="211" y="236" width="5" height="194"/>
                             </box>
                             <scrollView misplaced="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="23" horizontalPageScroll="10" verticalLineScroll="23" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nuw-B2-l9i">
                                 <rect key="frame" x="0.0" y="0.0" width="450" height="239"/>
@@ -608,7 +592,6 @@
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="21" headerView="ikZ-Ha-F7g" viewBased="YES" id="4OW-yt-24y">
                                             <rect key="frame" x="0.0" y="0.0" width="450" height="216"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                            <animations/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -630,9 +613,8 @@
                                                             <rect key="frame" x="1" y="1" width="171" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0YJ-ah-QhX">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0YJ-ah-QhX">
                                                                     <rect key="frame" x="0.0" y="0.0" width="170" height="20"/>
-                                                                    <animations/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="coffee" id="JEt-gG-F89">
                                                                         <font key="font" size="13" name="HelveticaNeue-Light"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -644,7 +626,6 @@
                                                                 <constraint firstItem="0YJ-ah-QhX" firstAttribute="leading" secondItem="qHx-ZN-FK9" secondAttribute="leading" constant="2" id="qUO-gL-dQn"/>
                                                                 <constraint firstAttribute="trailing" secondItem="0YJ-ah-QhX" secondAttribute="trailing" constant="2" id="szL-xf-awR"/>
                                                             </constraints>
-                                                            <animations/>
                                                             <connections>
                                                                 <outlet property="textField" destination="0YJ-ah-QhX" id="Vcl-vw-n0W"/>
                                                             </connections>
@@ -668,9 +649,8 @@
                                                             <rect key="frame" x="175.5" y="1" width="122" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ryZ-n8-Uzx">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ryZ-n8-Uzx">
                                                                     <rect key="frame" x="0.0" y="0.0" width="121" height="20"/>
-                                                                    <animations/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="—" id="z0I-7t-2TW">
                                                                         <font key="font" size="13" name="HelveticaNeue-Light"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -682,7 +662,6 @@
                                                                 <constraint firstAttribute="trailing" secondItem="ryZ-n8-Uzx" secondAttribute="trailing" constant="2" id="5Nx-ex-UPw"/>
                                                                 <constraint firstItem="ryZ-n8-Uzx" firstAttribute="leading" secondItem="Wls-u9-OB2" secondAttribute="leading" constant="2" id="ksX-pG-YWg"/>
                                                             </constraints>
-                                                            <animations/>
                                                             <connections>
                                                                 <outlet property="textField" destination="ryZ-n8-Uzx" id="NiS-Ne-nGg"/>
                                                             </connections>
@@ -703,12 +682,11 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="dateCell" id="7Sh-58-wXs">
-                                                            <rect key="frame" x="302" y="1" width="93" height="17"/>
+                                                            <rect key="frame" x="301" y="1" width="93" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="flk-XV-IvD">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="flk-XV-IvD">
                                                                     <rect key="frame" x="0.0" y="0.0" width="92" height="20"/>
-                                                                    <animations/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="Feb 1" id="ikh-aq-GOH">
                                                                         <font key="font" size="13" name="HelveticaNeue-Light"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -720,7 +698,6 @@
                                                                 <constraint firstAttribute="trailing" secondItem="flk-XV-IvD" secondAttribute="trailing" constant="2" id="D37-1r-lcE"/>
                                                                 <constraint firstItem="flk-XV-IvD" firstAttribute="leading" secondItem="7Sh-58-wXs" secondAttribute="leading" constant="2" id="Srd-OE-LES"/>
                                                             </constraints>
-                                                            <animations/>
                                                             <connections>
                                                                 <outlet property="textField" destination="flk-XV-IvD" id="wEW-Co-SjB"/>
                                                             </connections>
@@ -741,12 +718,11 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="valueCell" id="Eet-aI-AKw">
-                                                            <rect key="frame" x="398" y="1" width="50" height="17"/>
+                                                            <rect key="frame" x="397" y="1" width="50" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zLs-dM-Usb">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zLs-dM-Usb">
                                                                     <rect key="frame" x="0.0" y="0.0" width="50" height="20"/>
-                                                                    <animations/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" title="9.99" id="VK7-73-1Bm">
                                                                         <font key="font" size="13" name="HelveticaNeue-Light"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -758,7 +734,6 @@
                                                                 <constraint firstItem="zLs-dM-Usb" firstAttribute="leading" secondItem="Eet-aI-AKw" secondAttribute="leading" constant="2" id="YtO-4Z-jc7"/>
                                                                 <constraint firstAttribute="trailing" secondItem="zLs-dM-Usb" secondAttribute="trailing" constant="2" id="iLY-Hr-ZaH"/>
                                                             </constraints>
-                                                            <animations/>
                                                             <connections>
                                                                 <outlet property="textField" destination="zLs-dM-Usb" id="QVf-hc-jIm"/>
                                                             </connections>
@@ -771,39 +746,32 @@
                                             </connections>
                                         </tableView>
                                     </subviews>
-                                    <animations/>
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                 </clipView>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="450" id="Mak-zU-vVP"/>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="231" id="sab-Pi-aIV"/>
                                 </constraints>
-                                <animations/>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="i9B-1G-T2k">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="i9B-1G-T2k">
                                     <rect key="frame" x="1" y="105" width="211" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="xaV-U7-9F3">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="xaV-U7-9F3">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </scroller>
                                 <tableHeaderView key="headerView" id="ikZ-Ha-F7g">
                                     <rect key="frame" x="0.0" y="0.0" width="450" height="23"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </tableHeaderView>
                             </scrollView>
                             <datePicker toolTip="End date for filtering expenses" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="syt-nm-3yV">
                                 <rect key="frame" x="284" y="266" width="139" height="148"/>
-                                <animations/>
                                 <datePickerCell key="cell" lineBreakMode="truncatingMiddle" borderStyle="bezel" alignment="left" datePickerStyle="clockAndCalendar" id="z0V-zE-VUh">
                                     <font key="font" metaFont="system"/>
-                                    <calendarDate key="date" timeIntervalSinceReferenceDate="-595929600" calendarFormat="%Y-%m-%d %H:%M:%S %z">
-                                        <!--1982-02-12 08:00:00 -0800-->
-                                        <timeZone key="timeZone" name="US/Pacific"/>
-                                    </calendarDate>
+                                    <date key="date" timeIntervalSinceReferenceDate="-595929600">
+                                        <!--1982-02-12 16:00:00 +0000-->
+                                    </date>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <connections>
@@ -828,7 +796,6 @@
                             <constraint firstItem="Nuw-B2-l9i" firstAttribute="top" secondItem="syt-nm-3yV" secondAttribute="bottom" constant="19" id="qG1-eS-Uaa"/>
                             <constraint firstItem="V2b-ad-fx5" firstAttribute="top" secondItem="fgB-Ch-3fZ" secondAttribute="top" constant="10" id="rsu-nl-4wf"/>
                         </constraints>
-                        <animations/>
                     </view>
                     <connections>
                         <outlet property="expensesTableView" destination="4OW-yt-24y" id="hu7-7G-r0S"/>
@@ -850,45 +817,45 @@
                         <rect key="frame" x="0.0" y="0.0" width="231" height="497"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dc2-wY-D8P">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dc2-wY-D8P">
                                 <rect key="frame" x="18" y="451" width="195" height="26"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Value" id="KTF-0t-Mvk">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pKw-Tm-CE0">
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pKw-Tm-CE0">
                                 <rect key="frame" x="20" y="421" width="191" height="26"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" alignment="left" placeholderString="9.99" drawsBackground="YES" id="BDC-hN-a67">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="63H-13-4Qx">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="63H-13-4Qx">
                                 <rect key="frame" x="18" y="380" width="195" height="26"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Name" id="FJx-Zq-yB9">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Po6-oW-Yxy">
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Po6-oW-Yxy">
                                 <rect key="frame" x="20" y="350" width="191" height="26"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" alignment="left" placeholderString="coffee" drawsBackground="YES" id="Zvd-q5-ZvC">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vNw-FC-X48">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vNw-FC-X48">
                                 <rect key="frame" x="18" y="304" width="195" height="26"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Date" id="2eG-fP-SgW">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -897,20 +864,19 @@
                             </textField>
                             <datePicker verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vJ5-WV-GQw">
                                 <rect key="frame" x="46" y="154" width="139" height="148"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <datePickerCell key="cell" lineBreakMode="truncatingMiddle" borderStyle="bezel" alignment="left" datePickerStyle="clockAndCalendar" id="7ip-8T-K1W">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
-                                    <calendarDate key="date" timeIntervalSinceReferenceDate="-595929600" calendarFormat="%Y-%m-%d %H:%M:%S %z">
-                                        <!--1982-02-12 08:00:00 -0800-->
-                                        <timeZone key="timeZone" name="US/Pacific"/>
-                                    </calendarDate>
+                                    <date key="date" timeIntervalSinceReferenceDate="-595929600">
+                                        <!--1982-02-12 16:00:00 +0000-->
+                                    </date>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 </datePickerCell>
                             </datePicker>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iOp-Zc-n2c">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iOp-Zc-n2c">
                                 <rect key="frame" x="18" y="111" width="195" height="26"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Type" id="YuD-vC-G5l">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -919,7 +885,7 @@
                             </textField>
                             <popUpButton fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rM6-FX-lcN">
                                 <rect key="frame" x="18" y="78" width="195" height="31"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <popUpButtonCell key="cell" type="bevel" bezelStyle="regularSquare" imagePosition="overlaps" alignment="left" lineBreakMode="truncatingMiddle" continuous="YES" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" selectedItem="tkt-7b-7Go" id="Lun-Hh-8q0">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
@@ -937,7 +903,7 @@
                             </popUpButton>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5dI-1C-E9e">
                                 <rect key="frame" x="14" y="17" width="98" height="39"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="bevel" title="Update" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="yAJ-sX-olp">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
@@ -948,7 +914,7 @@
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="34W-9D-Lvv">
                                 <rect key="frame" x="115" y="17" width="98" height="39"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="bevel" title="Delete" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ADN-6g-U49">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
@@ -958,7 +924,6 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
                     </view>
                     <connections>
                         <outlet property="dateText" destination="vJ5-WV-GQw" id="N8d-n1-kXQ"/>
@@ -979,36 +944,32 @@
                         <rect key="frame" x="0.0" y="0.0" width="275" height="300"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="chf-0y-Acj">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="chf-0y-Acj">
                                 <rect key="frame" x="85" y="201" width="104" height="29"/>
-                                <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Total" id="qgE-jz-8ZC">
                                     <font key="font" size="24" name="HelveticaNeue-Light"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OAs-0s-5o8">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OAs-0s-5o8">
                                 <rect key="frame" x="90" y="114" width="94" height="17"/>
-                                <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="BY CATEGORY" id="xna-1u-7qj">
                                     <font key="font" size="11" name="HelveticaNeue-Light"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vmq-Fp-SYM">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmq-Fp-SYM">
                                 <rect key="frame" x="18" y="155" width="239" height="36"/>
-                                <animations/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" title="3767.25" id="W0p-kq-qbY">
                                     <font key="font" size="30" name="HelveticaNeue-Light"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <searchField wantsLayer="YES" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E8a-Zi-0F7">
+                            <searchField wantsLayer="YES" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E8a-Zi-0F7">
                                 <rect key="frame" x="55" y="258" width="165" height="20"/>
-                                <animations/>
                                 <searchFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Filter Expenses" drawsBackground="YES" usesSingleLineMode="YES" id="hIP-6f-ObS">
                                     <font key="font" size="13" name="HelveticaNeue-Light"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1018,7 +979,7 @@
                                     <action selector="enteredSearchText:" target="2eo-YP-dCz" id="SsM-sA-GhB"/>
                                 </connections>
                             </searchField>
-                            <scrollView ambiguous="YES" misplaced="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="25" horizontalPageScroll="10" verticalLineScroll="25" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ic1-Yg-dmq">
+                            <scrollView ambiguous="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="25" horizontalPageScroll="10" verticalLineScroll="25" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ic1-Yg-dmq">
                                 <rect key="frame" x="20" y="20" width="235" height="86"/>
                                 <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="Fqc-jL-Vwo">
                                     <rect key="frame" x="0.0" y="0.0" width="235" height="86"/>
@@ -1027,7 +988,6 @@
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" selectionHighlightStyle="none" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="25" viewBased="YES" id="CxY-2v-M5G">
                                             <rect key="frame" x="0.0" y="0.0" width="235" height="86"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                            <animations/>
                                             <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                             <color key="gridColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                             <tableColumns>
@@ -1045,12 +1005,12 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="checkedCell" id="pax-im-Ucq">
-                                                            <rect key="frame" x="1" y="1" width="16" height="20"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="16" height="20"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <button identifier="cellCheckbox" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nkk-Br-DXU">
                                                                     <rect key="frame" x="0.0" y="-1" width="16" height="18"/>
-                                                                    <animations/>
+                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="only" state="on" inset="2" id="Io8-7A-EQl">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                         <font key="font" metaFont="system"/>
@@ -1060,7 +1020,6 @@
                                                                     </connections>
                                                                 </button>
                                                             </subviews>
-                                                            <animations/>
                                                         </tableCellView>
                                                     </prototypeCellViews>
                                                 </tableColumn>
@@ -1081,9 +1040,9 @@
                                                             <rect key="frame" x="16" y="0.0" width="140" height="25"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jgy-nc-UT7">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jgy-nc-UT7">
                                                                     <rect key="frame" x="1" y="0.0" width="140" height="25"/>
-                                                                    <animations/>
+                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="uncategorized" id="Gft-Yf-7YE">
                                                                         <font key="font" size="13" name="HelveticaNeue-Thin"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1091,7 +1050,6 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                             </subviews>
-                                                            <animations/>
                                                             <connections>
                                                                 <outlet property="textField" destination="Jgy-nc-UT7" id="Fqy-jD-6Sr"/>
                                                             </connections>
@@ -1115,9 +1073,9 @@
                                                             <rect key="frame" x="156" y="0.0" width="60" height="25"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nRZ-Cr-uDQ">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nRZ-Cr-uDQ">
                                                                     <rect key="frame" x="0.0" y="0.0" width="60" height="25"/>
-                                                                    <animations/>
+                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="28" id="bE8-37-0Kc">
                                                                         <font key="font" size="13" name="HelveticaNeue-Thin"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1125,7 +1083,6 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                             </subviews>
-                                                            <animations/>
                                                             <connections>
                                                                 <outlet property="textField" destination="nRZ-Cr-uDQ" id="yKY-hf-lIv"/>
                                                             </connections>
@@ -1135,19 +1092,15 @@
                                             </tableColumns>
                                         </tableView>
                                     </subviews>
-                                    <animations/>
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                 </clipView>
-                                <animations/>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="egq-u9-FGr">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="egq-u9-FGr">
                                     <rect key="frame" x="1" y="117" width="237" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="fmo-mL-V6X">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="fmo-mL-V6X">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </scroller>
                             </scrollView>
                         </subviews>
@@ -1166,7 +1119,6 @@
                             <constraint firstAttribute="trailing" secondItem="vmq-Fp-SYM" secondAttribute="trailing" constant="20" id="vI0-Mi-DYq"/>
                             <constraint firstItem="ic1-Yg-dmq" firstAttribute="leading" secondItem="Qnj-cP-ZP7" secondAttribute="leading" constant="20" id="vqF-oM-TF8"/>
                         </constraints>
-                        <animations/>
                     </view>
                     <connections>
                         <outlet property="expenseTypesTableView" destination="CxY-2v-M5G" id="iIR-mr-BV2"/>
@@ -1186,19 +1138,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="450" height="271"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="K8F-9g-oeY">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K8F-9g-oeY">
                                 <rect key="frame" x="184" y="207" width="83" height="28"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Oikon" id="09M-J4-3ga">
                                     <font key="font" size="22" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="N33-aI-piB">
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N33-aI-piB">
                                 <rect key="frame" x="18" y="77" width="414" height="114"/>
-                                <animations/>
-                                <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" alignment="center" title="Oikon is a simple expense manager. No complications.  version 1.0  Brought to you by emotionLoop" id="WVz-jW-CdG">
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" alignment="center" title="Oikon is a simple expense manager. No complications.  version 1.0.2  Brought to you by emotionLoop" id="WVz-jW-CdG">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -1206,7 +1158,7 @@
                             </textField>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DhF-ZP-Ylb">
                                 <rect key="frame" x="46" y="17" width="174" height="35"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="bevel" title="Visit our website" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vdZ-nc-ec1">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="15" name="HelveticaNeue-Thin"/>
@@ -1217,7 +1169,7 @@
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jSr-hG-ccd">
                                 <rect key="frame" x="231" y="17" width="174" height="35"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="bevel" title="Get Help/Support" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="oFS-rF-kaC">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="15" name="HelveticaNeue-Thin"/>
@@ -1227,7 +1179,6 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
                     </view>
                 </viewController>
                 <customObject id="d7S-bR-sNa" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -1242,45 +1193,40 @@
                         <rect key="frame" x="0.0" y="0.0" width="280" height="637"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mT5-Sq-BTO">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mT5-Sq-BTO">
                                 <rect key="frame" x="57" y="591" width="167" height="26"/>
-                                <animations/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="How much did you spend?" id="ZxB-2v-w89">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Rr-ms-zn1">
-                                <rect key="frame" x="55" y="535" width="170" height="48"/>
-                                <animations/>
+                            <textField verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Rr-ms-zn1">
+                                <rect key="frame" x="55" y="535" width="170" height="44"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" alignment="center" placeholderString="9.99" drawsBackground="YES" id="gVM-oa-Ixi">
                                     <font key="font" size="36" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X3c-JR-llj">
-                                <rect key="frame" x="57" y="486" width="167" height="26"/>
-                                <animations/>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X3c-JR-llj">
+                                <rect key="frame" x="57" y="486" width="167" height="21"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="What was it?" id="NYN-GZ-Egh">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4VU-0g-KZ9">
-                                <rect key="frame" x="20" y="430" width="240" height="48"/>
-                                <animations/>
+                            <textField verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4VU-0g-KZ9">
+                                <rect key="frame" x="20" y="430" width="240" height="44"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" alignment="center" placeholderString="coffee" drawsBackground="YES" id="Hyw-Y8-i5N">
                                     <font key="font" size="36" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MwX-zK-eed">
-                                <rect key="frame" x="57" y="378" width="167" height="26"/>
-                                <animations/>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MwX-zK-eed">
+                                <rect key="frame" x="57" y="378" width="167" height="21"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="When was it?" id="mFF-RO-c6k">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1289,20 +1235,19 @@
                             </textField>
                             <datePicker verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Snj-d8-arT">
                                 <rect key="frame" x="71" y="217" width="139" height="148"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <datePickerCell key="cell" lineBreakMode="truncatingMiddle" borderStyle="bezel" alignment="left" datePickerStyle="clockAndCalendar" id="c63-EQ-CEY">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
-                                    <calendarDate key="date" timeIntervalSinceReferenceDate="-595929600" calendarFormat="%Y-%m-%d %H:%M:%S %z">
-                                        <!--1982-02-12 08:00:00 -0800-->
-                                        <timeZone key="timeZone" name="US/Pacific"/>
-                                    </calendarDate>
+                                    <date key="date" timeIntervalSinceReferenceDate="-595929600">
+                                        <!--1982-02-12 16:00:00 +0000-->
+                                    </date>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 </datePickerCell>
                             </datePicker>
                             <popUpButton fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OPw-BI-D0L">
                                 <rect key="frame" x="31" y="110" width="218" height="35"/>
-                                <animations/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <popUpButtonCell key="cell" type="bevel" bezelStyle="regularSquare" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" pullsDown="YES" selectedItem="g0Z-y2-cuf" id="PT9-1B-7Ow">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="16" name="HelveticaNeue-Thin"/>
@@ -1318,18 +1263,16 @@
                                     <action selector="typePopUpChanged:" target="vAb-TZ-zjr" id="fUs-au-9Mt"/>
                                 </connections>
                             </popUpButton>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Mfa-X7-zIc">
-                                <rect key="frame" x="57" y="156" width="181" height="26"/>
-                                <animations/>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mfa-X7-zIc">
+                                <rect key="frame" x="57" y="156" width="181" height="21"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="What type of expense was it?" id="1Ts-Ez-YLf">
                                     <font key="font" size="14" name="HelveticaNeue-Thin"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <button ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sDg-wS-tyi">
-                                <rect key="frame" x="14" y="17" width="252" height="47"/>
-                                <animations/>
+                            <button ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sDg-wS-tyi">
+                                <rect key="frame" x="14" y="17" width="252" height="35"/>
                                 <buttonCell key="cell" type="bevel" title="Add Expense" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyUpOrDown" inset="2" id="2wn-NO-SKV">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" size="16" name="HelveticaNeue-Thin"/>
@@ -1359,7 +1302,6 @@ DQ
                             <constraint firstAttribute="trailing" secondItem="MwX-zK-eed" secondAttribute="trailing" constant="58" id="uwe-mS-LSS"/>
                             <constraint firstItem="mT5-Sq-BTO" firstAttribute="leading" secondItem="KL8-NG-TFa" secondAttribute="leading" constant="59" id="wLI-Cz-xkF"/>
                         </constraints>
-                        <animations/>
                     </view>
                     <connections>
                         <outlet property="addExpenseButton" destination="sDg-wS-tyi" id="nj5-Vn-UzK"/>

--- a/Oikon/Base.lproj/Main.storyboard
+++ b/Oikon/Base.lproj/Main.storyboard
@@ -124,7 +124,7 @@
         <!--Oikon-->
         <scene sceneID="hIz-AP-VOD">
             <objects>
-                <viewController title="Oikon" showSeguePresentationStyle="single" id="XfG-lQ-9wD" customClass="ViewController" customModule="Oikon" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="Oikon" id="XfG-lQ-9wD" customClass="ViewController" customModule="Oikon" customModuleProvider="target" sceneMemberID="viewController">
                     <visualEffectView key="view" appearanceType="vibrantDark" blendingMode="behindWindow" material="appearanceBased" state="followsWindowActiveState" id="12f-OC-8cl">
                         <rect key="frame" x="0.0" y="0.0" width="300" height="405"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -140,7 +140,7 @@
                                     <string key="keyEquivalent">a</string>
                                 </buttonCell>
                                 <connections>
-                                    <segue destination="vAb-TZ-zjr" kind="modal" identifier="addExpense" id="xJn-Gg-vM9"/>
+                                    <segue destination="vAb-TZ-zjr" kind="show" identifier="addExpense" id="xJn-Gg-vM9"/>
                                 </connections>
                             </button>
                             <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="SXY-rz-dui">
@@ -154,7 +154,7 @@
                                     <string key="keyEquivalent">e</string>
                                 </buttonCell>
                                 <connections>
-                                    <segue destination="bVk-Xf-EYe" kind="modal" identifier="expenseTypes" id="5g6-nq-qdT"/>
+                                    <segue destination="bVk-Xf-EYe" kind="show" identifier="expenseTypes" id="5g6-nq-qdT"/>
                                 </connections>
                             </button>
                             <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="9ZJ-Mg-YS0">
@@ -168,7 +168,7 @@
                                     <string key="keyEquivalent">p</string>
                                 </buttonCell>
                                 <connections>
-                                    <segue destination="ji4-DL-0YU" kind="modal" identifier="pastExpensesOpen" id="Ik5-Yt-d6d"/>
+                                    <segue destination="ji4-DL-0YU" kind="show" identifier="pastExpensesOpen" id="Ik5-Yt-d6d"/>
                                 </connections>
                             </button>
                             <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="5FH-c7-YFT">
@@ -182,7 +182,7 @@
                                     <string key="keyEquivalent">s</string>
                                 </buttonCell>
                                 <connections>
-                                    <segue destination="wOn-k1-nU6" kind="modal" identifier="settings" id="cAv-bS-gHA"/>
+                                    <segue destination="wOn-k1-nU6" kind="show" identifier="settings" id="cAv-bS-gHA"/>
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ml8-XT-zyf">

--- a/Oikon/EditExpenseTypeViewController.swift
+++ b/Oikon/EditExpenseTypeViewController.swift
@@ -17,13 +17,13 @@ class EditExpenseTypeViewController: NSViewController {
     @IBOutlet var nameText: NSTextField!
     
     // Update expense type and update all the expenses with it
-    @IBAction func updateExpenseType(sender: AnyObject) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    @IBAction func updateExpenseType(_ sender: AnyObject) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let numberFormatter = NSNumberFormatter()
-        numberFormatter.locale = NSLocale.currentLocale()
-        numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale.current
+        numberFormatter.numberStyle = NumberFormatter.Style.decimal
         
         let uncategorizedStringValue = NSLocalizedString("uncategorized", comment: "")
         
@@ -31,8 +31,8 @@ class EditExpenseTypeViewController: NSViewController {
         var expenseTypeName: NSString = ""
         
         // Avoid empty values crashing the code
-        if let tmpExpenseTypeName: NSString? = self.nameText?.stringValue {
-            expenseTypeName = tmpExpenseTypeName!
+        if let tmpExpenseTypeName: NSString = self.nameText.stringValue as NSString? {
+            expenseTypeName = tmpExpenseTypeName
         }
         
         //NSLog("%@", expenseTypeName)
@@ -43,21 +43,21 @@ class EditExpenseTypeViewController: NSViewController {
         
         // Check if the expense type name is not empty
         if ( expenseTypeName.length <= 0 ) {
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Please confirm the name of the expense type.", comment:""), window: self.mainViewController.view.window!)
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Please confirm the name of the expense type.", comment:"") as NSString, window: self.mainViewController.view.window!)
             
             return;
         }
         
         // Check if the expense type name is "uncategorized" (case insensitive, not allowed)
-        if ( expenseTypeName.compare(uncategorizedStringValue) == NSComparisonResult.OrderedSame ) {
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Your expense type can't be called 'uncategorized'.", comment:""), window: self.mainViewController.view.window!)
+        if ( expenseTypeName.compare(uncategorizedStringValue) == ComparisonResult.orderedSame ) {
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Your expense type can't be called 'uncategorized'.", comment:"") as NSString, window: self.mainViewController.view.window!)
             
             return;
         }
         
         // Check if an expense type with that name already exists, and this name changed
         if ( expenseTypeName != originalExpenseTypeName && self.mainViewController.expenseTypeExists(expenseTypeName) ) {
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("An expense type with the same name already exists.", comment:""), window: self.mainViewController.view.window!)
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("An expense type with the same name already exists.", comment:"") as NSString, window: self.mainViewController.view.window!)
             
             return;
         }
@@ -70,7 +70,7 @@ class EditExpenseTypeViewController: NSViewController {
         // Save object
         //
         
-        let selectedExpenseType: NSManagedObject = self.mainViewController.expenseTypes.objectAtIndex(self.originalExpenseTypeIndex) as! NSManagedObject
+        let selectedExpenseType: NSManagedObject = self.mainViewController.expenseTypes.object(at: self.originalExpenseTypeIndex) as! NSManagedObject
         
         selectedExpenseType.setValue(expenseTypeName, forKey: "name")
         
@@ -89,13 +89,13 @@ class EditExpenseTypeViewController: NSViewController {
         } else {
             NSLog("Error: %@", error!)
             
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("There was an error updating your expense type. Please confirm the value types match.", comment:""), window: self.mainViewController.view.window!)
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("There was an error updating your expense type. Please confirm the value types match.", comment:"") as NSString, window: self.mainViewController.view.window!)
         }
         
         // Update all expenses with that expense type
-        let entityDesc = NSEntityDescription.entityForName("Expense", inManagedObjectContext:context!)
+        let entityDesc = NSEntityDescription.entity(forEntityName: "Expense", in:context!)
         
-        let request = NSFetchRequest()
+        let request = NSFetchRequest<NSFetchRequestResult>()
         request.entity = entityDesc
         
         // Add expense type name to update only the expenses that match it
@@ -104,7 +104,7 @@ class EditExpenseTypeViewController: NSViewController {
         
         var objects: [NSManagedObject]
         
-        objects = (try! context!.executeFetchRequest(request)) as! [NSManagedObject]
+        objects = (try! context!.fetch(request)) as! [NSManagedObject]
         
         if ( error == nil ) {
             for object: NSManagedObject in objects {
@@ -129,18 +129,18 @@ class EditExpenseTypeViewController: NSViewController {
     }
     
     // Delete expense type and remove it from all expenses with it
-    @IBAction func deleteExpenseType(sender: AnyObject) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    @IBAction func deleteExpenseType(_ sender: AnyObject) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let expenseTypeToRemove: NSManagedObject = self.mainViewController.expenseTypes.objectAtIndex( self.originalExpenseTypeIndex ) as! NSManagedObject
+        let expenseTypeToRemove: NSManagedObject = self.mainViewController.expenseTypes.object( at: self.originalExpenseTypeIndex ) as! NSManagedObject
         
-        let buttonPressed = self.mainViewController.mainViewController.showConfirm( NSLocalizedString("Are you sure you want to delete this expense type?", comment: "") )
+        let buttonPressed = self.mainViewController.mainViewController.showConfirm( NSLocalizedString("Are you sure you want to delete this expense type?", comment: "") as NSString )
         
         // Confirmed!
         if buttonPressed == NSAlertSecondButtonReturn {
             // Delete from core data
-            context?.deleteObject(expenseTypeToRemove)
+            context?.delete(expenseTypeToRemove)
             
             var error: NSError? = nil
             do {
@@ -151,7 +151,7 @@ class EditExpenseTypeViewController: NSViewController {
             
             if ( error == nil ) {
                 // Delete from view
-                self.mainViewController.expenseTypes.removeObjectAtIndex(self.originalExpenseTypeIndex)
+                self.mainViewController.expenseTypes.removeObject(at: self.originalExpenseTypeIndex)
                 
                 // Refresh the table in the mainViewController
                 self.mainViewController.getAllExpenseTypes()
@@ -160,9 +160,9 @@ class EditExpenseTypeViewController: NSViewController {
             }
             
             // Change all expenses with this expense type to nil
-            let entityDesc = NSEntityDescription.entityForName("Expense", inManagedObjectContext:context!)
+            let entityDesc = NSEntityDescription.entity(forEntityName: "Expense", in:context!)
             
-            let request = NSFetchRequest()
+            let request = NSFetchRequest<NSFetchRequestResult>()
             request.entity = entityDesc
             
             // Add expense type name to update only the expenses that match it
@@ -171,7 +171,7 @@ class EditExpenseTypeViewController: NSViewController {
             
             var objects: [NSManagedObject]
             
-            objects = (try! context!.executeFetchRequest(request)) as! [NSManagedObject]
+            objects = (try! context!.fetch(request)) as! [NSManagedObject]
             
             if ( error == nil ) {
                 for object: NSManagedObject in objects {

--- a/Oikon/EditExpenseViewController.swift
+++ b/Oikon/EditExpenseViewController.swift
@@ -36,12 +36,24 @@ class EditExpenseViewController: NSViewController {
         var expenseType: NSString? = uncategorizedStringValue as NSString
         var expenseDate: Date = Date()// Default expense date to "now"
         
+        // Replace comma decimal to dot decimal
+        if (numberFormatter.currencyDecimalSeparator == ".") {
+            let tmpVal = self.valueText.stringValue.replacingOccurrences(of: ",", with: ".")
+            self.valueText.stringValue = tmpVal
+        }
+        
+        // Replace dot decimal to comma decimal
+        if (numberFormatter.currencyDecimalSeparator == ",") {
+            let tmpVal = self.valueText.stringValue.replacingOccurrences(of: ".", with: ",")
+            self.valueText.stringValue = tmpVal
+        }
+        
         // Avoid empty values crashing the code
         if let tmpExpenseValue: NSNumber = numberFormatter.number(from: self.valueText.stringValue) {
             expenseValue = tmpExpenseValue
         }
         if let tmpExpenseName: NSString = self.nameText.stringValue as NSString? {
-            expenseName = tmpExpenseName
+            expenseName = tmpExpenseName// We intentionally don't trim on update
         }
         if let tmpExpenseType: NSString = self.typeText.titleOfSelectedItem! as NSString? {
             expenseType = tmpExpenseType
@@ -56,7 +68,7 @@ class EditExpenseViewController: NSViewController {
         // START: Validate fields for common errors
         //
         
-        // Check if value is greater than 0
+        // Check if value is not 0
         if ( !expenseValue.boolValue ) {
             self.mainViewController.mainViewController.showAlert(NSLocalizedString("Please confirm the value of the expense.", comment:"") as NSString, window: self.view.window!)
             

--- a/Oikon/EditExpenseViewController.swift
+++ b/Oikon/EditExpenseViewController.swift
@@ -20,24 +20,24 @@ class EditExpenseViewController: NSViewController {
     @IBOutlet var typeText: NSPopUpButton!
     
     // Update expense
-    @IBAction func updateExpense(sender: AnyObject) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    @IBAction func updateExpense(_ sender: AnyObject) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let numberFormatter = NSNumberFormatter()
-        numberFormatter.locale = NSLocale.currentLocale()
-        numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale.current
+        numberFormatter.numberStyle = NumberFormatter.Style.decimal
         
         let uncategorizedStringValue = NSLocalizedString("uncategorized", comment: "")
         
         // Set defaults
         var expenseValue: NSNumber = 0
         var expenseName: NSString = ""
-        var expenseType: NSString? = uncategorizedStringValue
-        var expenseDate: NSDate = NSDate()// Default expense date to "now"
+        var expenseType: NSString? = uncategorizedStringValue as NSString
+        var expenseDate: Date = Date()// Default expense date to "now"
         
         // Avoid empty values crashing the code
-        if let tmpExpenseValue: NSNumber = numberFormatter.numberFromString(self.valueText.stringValue) {
+        if let tmpExpenseValue: NSNumber = numberFormatter.number(from: self.valueText.stringValue) {
             expenseValue = tmpExpenseValue
         }
         if let tmpExpenseName: NSString = self.nameText.stringValue as NSString? {
@@ -46,7 +46,7 @@ class EditExpenseViewController: NSViewController {
         if let tmpExpenseType: NSString = self.typeText.titleOfSelectedItem! as NSString? {
             expenseType = tmpExpenseType
         }
-        if let tmpExpenseDate: NSDate = self.dateText.dateValue as NSDate? {
+        if let tmpExpenseDate: Date = self.dateText.dateValue as Date? {
             expenseDate = tmpExpenseDate
         }
         
@@ -58,14 +58,14 @@ class EditExpenseViewController: NSViewController {
         
         // Check if value is greater than 0
         if ( !expenseValue.boolValue ) {
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Please confirm the value of the expense.", comment:""), window: self.view.window!)
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Please confirm the value of the expense.", comment:"") as NSString, window: self.view.window!)
             
             return;
         }
         
         // Check if the expense name is not empty
         if ( expenseName.length <= 0 ) {
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Please confirm the name of the expense.", comment:""), window: self.view.window!)
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("Please confirm the name of the expense.", comment:"") as NSString, window: self.view.window!)
             
             return;
         }
@@ -75,7 +75,7 @@ class EditExpenseViewController: NSViewController {
         //
         
         // Check if the expense type is empty (if empty or uncategorized, set to nil)
-        if ( expenseType!.length <= 0 || expenseType!.isEqualToString(uncategorizedStringValue) ) {
+        if ( expenseType!.length <= 0 || expenseType!.isEqual(to: uncategorizedStringValue) ) {
             expenseType = nil
         }
         
@@ -83,7 +83,7 @@ class EditExpenseViewController: NSViewController {
         // Save object
         //
         
-        let expenseBeingUpdated: NSManagedObject = self.mainViewController.expenses.objectAtIndex(self.indexOfExpenseBeingEdited) as! NSManagedObject
+        let expenseBeingUpdated: NSManagedObject = self.mainViewController.expenses.object(at: self.indexOfExpenseBeingEdited) as! NSManagedObject
         expenseBeingUpdated.setValue(expenseValue, forKey: "value")
         expenseBeingUpdated.setValue(expenseName, forKey: "name")
         expenseBeingUpdated.setValue(expenseType, forKey: "type")
@@ -101,7 +101,7 @@ class EditExpenseViewController: NSViewController {
         } else {
             NSLog("Error: %@", error!)
             
-            self.mainViewController.mainViewController.showAlert(NSLocalizedString("There was an error updating your expense. Please confirm the value types match.", comment:""), window: self.view.window!)
+            self.mainViewController.mainViewController.showAlert(NSLocalizedString("There was an error updating your expense. Please confirm the value types match.", comment:"") as NSString, window: self.view.window!)
         }
         
         // Update expenses list
@@ -112,18 +112,18 @@ class EditExpenseViewController: NSViewController {
     }
     
     // Delete expense
-    @IBAction func deleteExpense(sender: AnyObject) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    @IBAction func deleteExpense(_ sender: AnyObject) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let expenseToRemove: NSManagedObject = self.mainViewController.expenses.objectAtIndex( self.indexOfExpenseBeingEdited ) as! NSManagedObject
+        let expenseToRemove: NSManagedObject = self.mainViewController.expenses.object( at: self.indexOfExpenseBeingEdited ) as! NSManagedObject
         
-        let buttonPressed = self.mainViewController.mainViewController.showConfirm( NSLocalizedString("Are you sure you want to delete this expense?", comment: "") )
+        let buttonPressed = self.mainViewController.mainViewController.showConfirm( NSLocalizedString("Are you sure you want to delete this expense?", comment: "") as NSString )
         
         // Confirmed!
         if buttonPressed == NSAlertSecondButtonReturn {
             // Delete from core data
-            context?.deleteObject(expenseToRemove)
+            context?.delete(expenseToRemove)
             
             var error: NSError? = nil
             do {
@@ -134,7 +134,7 @@ class EditExpenseViewController: NSViewController {
             
             if ( error == nil ) {
                 // Delete from view
-                self.mainViewController.expenses.removeObjectAtIndex(self.indexOfExpenseBeingEdited)
+                self.mainViewController.expenses.removeObject(at: self.indexOfExpenseBeingEdited)
                 
                 // Update the expenses list
                 self.mainViewController.getAllExpenses()
@@ -161,34 +161,34 @@ class EditExpenseViewController: NSViewController {
         expenseTypeStrings.append( uncategorizedString )
         
         for expenseType in self.mainViewController.expenseTypes {
-            expenseTypeStrings.append( expenseType.valueForKey("name") as! String )
+            expenseTypeStrings.append( (expenseType as AnyObject).value(forKey: "name") as! String )
         }
         
         self.typeText.removeAllItems()
-        self.typeText.addItemsWithTitles(expenseTypeStrings)
+        self.typeText.addItems(withTitles: expenseTypeStrings)
         
         // Fill up UI with details from the selected expense
         
-        let expenseBeingUpdated: NSManagedObject = self.mainViewController.expenses.objectAtIndex(self.indexOfExpenseBeingEdited) as! NSManagedObject
+        let expenseBeingUpdated: NSManagedObject = self.mainViewController.expenses.object(at: self.indexOfExpenseBeingEdited) as! NSManagedObject
         
         // Format Value
-        var valueString: AnyObject? = expenseBeingUpdated.valueForKey("value")
-        let numberFormatter = NSNumberFormatter()
-        numberFormatter.locale = NSLocale.currentLocale()
-        numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
+        var valueString: AnyObject? = expenseBeingUpdated.value(forKey: "value") as AnyObject
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale.current
+        numberFormatter.numberStyle = NumberFormatter.Style.decimal
         
-        valueString = NSString(format:"%@", numberFormatter.stringFromNumber(NSNumber(float: valueString as! Float))!)
+        valueString = NSString(format:"%@", numberFormatter.string(from: NSNumber(value: valueString as! Float as Float))!)
         
         self.valueText.stringValue = valueString as! String
-        self.nameText.stringValue = expenseBeingUpdated.valueForKey("name") as! String
-        self.dateText.dateValue = expenseBeingUpdated.valueForKey("date") as! NSDate
+        self.nameText.stringValue = expenseBeingUpdated.value(forKey: "name") as! String
+        self.dateText.dateValue = expenseBeingUpdated.value(forKey: "date") as! Date
         
         // Select proper expense type
-        if let selectedType: AnyObject = expenseBeingUpdated.valueForKey("type") {
-            self.typeText.selectItemWithTitle(selectedType as! String)
+        if let selectedType: AnyObject = expenseBeingUpdated.value(forKey: "type") as AnyObject? {
+            self.typeText.selectItem(withTitle: selectedType as! String)
             self.typeText.setTitle(selectedType as! String)
         } else {
-            self.typeText.selectItemWithTitle(uncategorizedString)
+            self.typeText.selectItem(withTitle: uncategorizedString)
             self.typeText.setTitle(uncategorizedString)
         }
     }
@@ -197,7 +197,7 @@ class EditExpenseViewController: NSViewController {
     }
     
     // This is what visually updates the selected item when the popup is changed
-    @IBAction func typePopUpChanged(sender: AnyObject) {
+    @IBAction func typePopUpChanged(_ sender: AnyObject) {
         self.typeText.setTitle( self.typeText.titleOfSelectedItem! )
     }
 

--- a/Oikon/ExpensesListSidebarViewController.swift
+++ b/Oikon/ExpensesListSidebarViewController.swift
@@ -101,6 +101,11 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
         
         // Reload view with new data
         self.expenseTypesTableView.reloadData()
+        
+        // Enable self.searchText's clear button
+        //let maskLayer = CALayer()
+        //self.searchText.layer = maskLayer
+        //maskLayer.backgroundColor = self.searchText.backgroundColor?.cgColor
     }
     
     override func viewWillAppear() {

--- a/Oikon/ExpensesListSidebarViewController.swift
+++ b/Oikon/ExpensesListSidebarViewController.swift
@@ -17,26 +17,26 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
     var listViewController: ExpensesListViewController!
     var mainViewController: ViewController!
     
-    var lastiCloudFetch: NSDate?
+    var lastiCloudFetch: Date?
 
     @IBOutlet var totalText: NSTextField!
     @IBOutlet var searchText: NSSearchField!
 
     @IBOutlet weak var expenseTypesTableView: NSTableView!
     
-    @IBAction func enteredSearchText(sender: AnyObject) {
+    @IBAction func enteredSearchText(_ sender: AnyObject) {
         // Update filter
-        self.listViewController.currentFilterName = searchText.stringValue
+        self.listViewController.currentFilterName = searchText.stringValue as NSString
         
         // Get filtered expenses
         self.listViewController.getAllExpenses()
     }
     
     // Action clicking on checkbox
-    @IBAction func checkboxStateChanged(sender: NSButton!) {
+    @IBAction func checkboxStateChanged(_ sender: NSButton!) {
         let isRemoving: Bool = ( sender.state == NSOffState )
         let expenseTypeIndex = sender.tag - 1
-        let expenseTypeName: String = self.listViewController.expenseTypes.objectAtIndex(expenseTypeIndex).valueForKey("name") as! String
+        let expenseTypeName: String = (self.listViewController.expenseTypes.object(at: expenseTypeIndex) as AnyObject).value(forKey: "name") as! String
         
         /*NSLog("INDEX = %d", expenseTypeIndex)
         if ( isRemoving ) {
@@ -49,23 +49,23 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
         if ( self.selectedExpenseTypeNames.count == 0 && isRemoving ) {
             //NSLog("ADDING EVERYTHING TO ARRAY")
             for expenseType in self.listViewController.expenseTypes {
-                self.selectedExpenseTypeNames.addObject(expenseType.valueForKey("name")!)
+                self.selectedExpenseTypeNames.add((expenseType as AnyObject).value(forKey: "name")!)
             }
         }
         
-        let foundIndex = self.selectedExpenseTypeNames.indexOfObject(expenseTypeName)
+        let foundIndex = self.selectedExpenseTypeNames.index(of: expenseTypeName)
         
         //NSLog("FOUND INDEX = %d", foundIndex)
         
         // If we're removing, do it
         if ( isRemoving ) {
-            self.selectedExpenseTypeNames.removeObjectAtIndex(foundIndex)
+            self.selectedExpenseTypeNames.removeObject(at: foundIndex)
         } else {
             if ( foundIndex != NSNotFound ) {
                 // It's already there, do nothing!?
                 NSLog("WARNING: Trying to add an expense type to filters, when it's already there. This should not happen!!")
             } else {
-                self.selectedExpenseTypeNames.addObject(expenseTypeName)
+                self.selectedExpenseTypeNames.add(expenseTypeName)
             }
         }
         
@@ -88,11 +88,11 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
         // Do view setup here.
         
         // Listen for iCloud changes (after it's done)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "iCloudDidUpdate:", name: NSPersistentStoreCoordinatorStoresDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ExpensesListSidebarViewController.iCloudDidUpdate(_:)), name: NSNotification.Name.NSPersistentStoreCoordinatorStoresDidChange, object: nil)
         
         // Make sure the table loads data from and listens to this controller
-        expenseTypesTableView.setDelegate(self)
-        expenseTypesTableView.setDataSource(self)
+        expenseTypesTableView.delegate = self
+        expenseTypesTableView.dataSource = self
         
         self.selectedExpenseTypeNames = NSMutableArray(array: self.listViewController.currentFilterTypes)
         
@@ -107,18 +107,19 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
     }
     
     // Calculate and show total for all found expenses
-    func calculateAndShowTotal( expenses:NSMutableArray ) {
+    func calculateAndShowTotal( _ expenses:NSMutableArray ) {
         var expensesTotal: Double = 0;
     
-        for expense: AnyObject in expenses {
-            expensesTotal += expense.valueForKey("value") as! Double
+        for _expense in expenses {
+            let expense = _expense as AnyObject
+            expensesTotal += expense.value(forKey: "value") as! Double
         }
         
-        let numberFormatter = NSNumberFormatter()
-        numberFormatter.locale = NSLocale.currentLocale()
-        numberFormatter.numberStyle = NSNumberFormatterStyle.CurrencyStyle
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale.current
+        numberFormatter.numberStyle = NumberFormatter.Style.currency
     
-        let formattedTotal:String = numberFormatter.stringFromNumber(NSNumber(double: expensesTotal))!
+        let formattedTotal:String = numberFormatter.string(from: NSNumber(value: expensesTotal as Double))!
         
         //NSLog("Calculating total = %@", formattedTotal)
         
@@ -128,17 +129,17 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
         }
     }
     
-    func numberOfRowsInTableView(aTableView: NSTableView) -> Int {
+    func numberOfRows(in aTableView: NSTableView) -> Int {
         let numberOfRows:Int = self.listViewController.expenseTypes.count
         return numberOfRows
     }
     
     // Format & Display Row Cells
-    func tableView(tableView: NSTableView, viewForTableColumn tableColumn: NSTableColumn?, row: Int) -> NSView? {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
         
         let cellIdentifier = NSString(format: "%@Cell", tableColumn!.identifier) as String!
         
-        let result: NSTableCellView = self.expenseTypesTableView.makeViewWithIdentifier(cellIdentifier, owner: self.expenseTypesTableView) as! NSTableCellView
+        let result: NSTableCellView = self.expenseTypesTableView.make(withIdentifier: cellIdentifier!, owner: self.expenseTypesTableView) as! NSTableCellView
         
         var stringValue: NSString!
         
@@ -146,7 +147,7 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
         if ( tableColumn!.identifier == "checked" ) {
             let checkboxView = result.subviews[0] as! NSButton
 
-            let expenseTypeName = self.listViewController.expenseTypes.objectAtIndex(row).valueForKey("name") as! NSString
+            let expenseTypeName = (self.listViewController.expenseTypes.object(at: row) as AnyObject).value(forKey: "name") as! NSString
             
             // Set tag so we can "find it" after, when clicking on it
             checkboxView.tag = row + 1
@@ -155,7 +156,7 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
             if ( self.selectedExpenseTypeNames.count == 0 ) {
                 checkboxView.state = NSOnState
             } else {
-                if ( self.selectedExpenseTypeNames.containsObject(expenseTypeName) ) {
+                if ( self.selectedExpenseTypeNames.contains(expenseTypeName) ) {
                     checkboxView.state = NSOnState
                 } else {
                     checkboxView.state = NSOffState
@@ -167,15 +168,15 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
         
         // Format Count
         if ( tableColumn!.identifier == "count" ) {
-            let numberOfExpenses = self.listViewController.getExpenseTypeSum( self.listViewController.expenseTypes.objectAtIndex(row).valueForKey("name") as! NSString ) as Float
-            let numberFormatter = NSNumberFormatter()
-            numberFormatter.locale = NSLocale.currentLocale()
-            numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
+            let numberOfExpenses = self.listViewController.getExpenseTypeSum( (self.listViewController.expenseTypes.object(at: row) as AnyObject).value(forKey: "name") as! NSString ) as NSNumber
+            let numberFormatter = NumberFormatter()
+            numberFormatter.locale = Locale.current
+            numberFormatter.numberStyle = NumberFormatter.Style.decimal
             
-            stringValue = numberFormatter.stringFromNumber(numberOfExpenses)
+            stringValue = numberFormatter.string(from: numberOfExpenses)! as NSString
         } else {
             // Format Name
-            stringValue = self.listViewController.expenseTypes.objectAtIndex( row ).valueForKey( tableColumn!.identifier ) as! NSString!
+            stringValue = (self.listViewController.expenseTypes.object( at: row ) as AnyObject).value( forKey: tableColumn!.identifier ) as! NSString!
         }
         
         result.textField!.stringValue = stringValue as String
@@ -184,7 +185,7 @@ class ExpensesListSidebarViewController: NSViewController, NSTableViewDataSource
     }
     
     // iCloud just finished updating
-    @IBAction func iCloudDidUpdate( sender: AnyObject? ) {
+    @IBAction func iCloudDidUpdate( _ sender: AnyObject? ) {
         // TODO: This is causing some unnecessary instability
         /*// This was creating an infinite loop, so we only allow this to run once every minute tops.
         let codeHasRunInThePastMinute: Bool

--- a/Oikon/ExpensesListViewController.swift
+++ b/Oikon/ExpensesListViewController.swift
@@ -190,7 +190,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         let usedPredicates = NSMutableArray()
     
         // Add dates to search
-        let datesPredicate = NSPredicate(format: "(date >= %@) and (date <= %@)", self.currentFromDate! as CVarArg, self.currentToDate! as CVarArg)
+        let datesPredicate = NSPredicate(format: "(date >= %@) and (date <= %@)", self.currentFromDate! as NSDate, self.currentToDate! as NSDate)
         
         usedPredicates.add(datesPredicate)
 
@@ -452,7 +452,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         let usedPredicates = NSMutableArray()
         
         // Add dates to search
-        let datesPredicate = NSPredicate(format: "(date >= %@) and (date <= %@)", self.currentFromDate as! CVarArg, self.currentToDate as! CVarArg)
+        let datesPredicate = NSPredicate(format: "(date >= %@) and (date <= %@)", self.currentFromDate as NSDate, self.currentToDate as NSDate)
         
         usedPredicates.add(datesPredicate)
         

--- a/Oikon/ExpensesListViewController.swift
+++ b/Oikon/ExpensesListViewController.swift
@@ -15,20 +15,20 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     // Set default expenses array
     var expenses: NSMutableArray! = []
     var expenseTypes: NSMutableArray! = []
-    var currentFromDate: NSDate!
-    var currentToDate: NSDate!
+    var currentFromDate: Date!
+    var currentToDate: Date!
     var currentFilterName: NSString!
     var currentFilterTypes: NSMutableArray! = []
     let uncategorizedStringValue = NSLocalizedString("uncategorized", comment: "")
     
-    var settings: NSUserDefaults!
+    var settings: UserDefaults!
     
     var sidebarViewController: ExpensesListSidebarViewController!
     var mainViewController: ViewController!
     
     var selectedExpenseIndex: Int!
     
-    var lastiCloudFetch: NSDate?
+    var lastiCloudFetch: Date?
     
     @IBOutlet var fromDateText: NSDatePicker!
     @IBOutlet var toDateText: NSDatePicker!
@@ -36,7 +36,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     @IBOutlet var expensesTableView: NSTableView!
 
     // From Date was changed
-    @IBAction func changedFromDate(sender: AnyObject) {
+    @IBAction func changedFromDate(_ sender: AnyObject) {
         self.currentFromDate = self.fromDateText.dateValue
         
         // Update Settings & UI
@@ -48,7 +48,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     }
 
     // To Date was changed
-    @IBAction func changedToDate(sender: AnyObject) {
+    @IBAction func changedToDate(_ sender: AnyObject) {
         self.currentToDate = self.toDateText.dateValue
         
         // Update Settings & UI
@@ -64,7 +64,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         // Do view setup here.
         
         // Listen for iCloud changes (after it's done)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "iCloudDidUpdate:", name: NSPersistentStoreCoordinatorStoresDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ExpensesListViewController.iCloudDidUpdate(_:)), name: NSNotification.Name.NSPersistentStoreCoordinatorStoresDidChange, object: nil)
         
         self.thisController = self
         
@@ -80,8 +80,8 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         }
         
         // Make sure the table loads data from and listens to this controller
-        expensesTableView.setDelegate(self)
-        expensesTableView.setDataSource(self)
+        expensesTableView.delegate = self
+        expensesTableView.dataSource = self
         
         // Make sure the date fields are listening to this controller for changes
         self.fromDateText.delegate = self
@@ -101,12 +101,12 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     
     // Set from and to dates to the current month (first and last day)
     func setDefaultSearchDates() {
-        let dateFormatter = NSDateFormatter()
-        let currentDate = NSDate()
-        let currentCalendar = NSCalendar.currentCalendar()
-        let calendarUnits: NSCalendarUnit = [NSCalendarUnit.Year, NSCalendarUnit.Month, NSCalendarUnit.Day]
+        let dateFormatter = DateFormatter()
+        let currentDate = Date()
+        let currentCalendar = Calendar.current
+        let calendarUnits: NSCalendar.Unit = [NSCalendar.Unit.year, NSCalendar.Unit.month, NSCalendar.Unit.day]
 
-        let dateComponents = currentCalendar.components(calendarUnits, fromDate: currentDate)
+        var dateComponents = (currentCalendar as NSCalendar).components(calendarUnits, from: currentDate)
     
         // Set format for text views
         dateFormatter.dateFormat = NSLocalizedString("MMM, d yyyy", comment: "")
@@ -115,7 +115,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         // Set "from date"
         //
         dateComponents.day = 1
-        self.currentFromDate = currentCalendar.dateFromComponents(dateComponents)
+        self.currentFromDate = currentCalendar.date(from: dateComponents)
     
         // Set "from date" text field
         //self.fromDateText.stringValue = dateFormatter.stringFromDate(self.currentFromDate)
@@ -124,10 +124,10 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         //
         // Set "to date"
         //
-        let daysRange: NSRange = currentCalendar.rangeOfUnit(NSCalendarUnit.Day, inUnit: NSCalendarUnit.Month, forDate: currentDate)
+        let daysRange: NSRange = (currentCalendar as NSCalendar).range(of: NSCalendar.Unit.day, in: NSCalendar.Unit.month, for: currentDate)
         dateComponents.day = daysRange.length// Last day of the current month
         
-        self.currentToDate = currentCalendar.dateFromComponents(dateComponents)
+        self.currentToDate = currentCalendar.date(from: dateComponents)
     
         // Set "to date" text
         //self.toDateText.stringValue = dateFormatter.stringFromDate(self.currentToDate)
@@ -136,12 +136,12 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     
     // Get all expenses from a range (set in self.currentFromDate and self.currentToDate)
     func getAllExpenses() {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let entityDesc = NSEntityDescription.entityForName("Expense", inManagedObjectContext:context!)
+        let entityDesc = NSEntityDescription.entity(forEntityName: "Expense", in:context!)
     
-        let request = NSFetchRequest()
+        let request = NSFetchRequest<NSFetchRequestResult>()
         request.entity = entityDesc
     
         // Sort expenses by date
@@ -162,24 +162,24 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         //
     
         // Make start date's time = 00:00:00
-        let currentCalendar = NSCalendar.currentCalendar()
-        let calendarUnits: NSCalendarUnit = [NSCalendarUnit.Year, NSCalendarUnit.Month, NSCalendarUnit.Day, NSCalendarUnit.Hour, NSCalendarUnit.Minute, NSCalendarUnit.Second]
-        let fromDateComponents = currentCalendar.components(calendarUnits, fromDate: self.currentFromDate)
+        let currentCalendar = Calendar.current
+        let calendarUnits: NSCalendar.Unit = [NSCalendar.Unit.year, NSCalendar.Unit.month, NSCalendar.Unit.day, NSCalendar.Unit.hour, NSCalendar.Unit.minute, NSCalendar.Unit.second]
+        var fromDateComponents = (currentCalendar as NSCalendar).components(calendarUnits, from: self.currentFromDate)
     
         fromDateComponents.hour = 0
         fromDateComponents.minute = 0
         fromDateComponents.second = 0
 
-        self.currentFromDate = currentCalendar.dateFromComponents(fromDateComponents)
+        self.currentFromDate = currentCalendar.date(from: fromDateComponents)
     
         // Make end date's time = 23:59:59
-        let toDateComponents = currentCalendar.components(calendarUnits, fromDate: self.currentToDate)
+        var toDateComponents = (currentCalendar as NSCalendar).components(calendarUnits, from: self.currentToDate)
     
         toDateComponents.hour = 23
         toDateComponents.minute = 59
         toDateComponents.second = 59
         
-        self.currentToDate = currentCalendar.dateFromComponents(toDateComponents)
+        self.currentToDate = currentCalendar.date(from: toDateComponents)
     
         //
         // Update search settings and search
@@ -190,9 +190,9 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         let usedPredicates = NSMutableArray()
     
         // Add dates to search
-        let datesPredicate = NSPredicate(format: "(date >= %@) and (date <= %@)", self.currentFromDate, self.currentToDate)
+        let datesPredicate = NSPredicate(format: "(date >= %@) and (date <= %@)", self.currentFromDate! as CVarArg, self.currentToDate! as CVarArg)
         
-        usedPredicates.addObject(datesPredicate)
+        usedPredicates.add(datesPredicate)
 
         // Add any self.currentFilterTypes to search
         let filterTypesPredicate: NSPredicate
@@ -200,7 +200,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         if ( self.currentFilterTypes.count > 0 ) {
             let uncategorizedText = NSLocalizedString("uncategorized", comment: "")
             
-            let hasUncategorized:Bool = self.currentFilterTypes.containsObject(uncategorizedText)
+            let hasUncategorized:Bool = self.currentFilterTypes.contains(uncategorizedText)
             
             // Parse the array, removing "uncategorized"
             let parsedFilterTypes = mainViewController.parseFilterTypes(self.currentFilterTypes)
@@ -217,7 +217,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
                 filterTypesPredicate = NSPredicate(format: "(type = nil)")
             }
             
-            usedPredicates.addObject(filterTypesPredicate)
+            usedPredicates.add(filterTypesPredicate)
         }
     
         // Add any self.currentFilterName to search
@@ -225,7 +225,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         if ( self.currentFilterName.length > 0 ) {
             filterNamePredicate = NSPredicate(format: "(name CONTAINS[cd] %@)", self.currentFilterName)
     
-            usedPredicates.addObject(filterNamePredicate)
+            usedPredicates.add(filterNamePredicate)
         }
 
         // Add the predicate to the request
@@ -235,7 +235,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         var objects: NSArray
         
         let error: NSError? = nil
-        objects = try! context!.executeFetchRequest(request)
+        objects = try! context!.fetch(request) as NSArray
         
         if ( error != nil ) {
             objects = []
@@ -254,7 +254,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     
     // Fetch search settings
     func fetchSearchSettings() {
-        self.settings = NSUserDefaults.standardUserDefaults()
+        self.settings = UserDefaults.standard
         self.settings.synchronize()
         
         var shouldUpdateUI:Bool = false
@@ -263,12 +263,12 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         // Dates
         //
         
-        if let currentSearchFromDate = self.settings.valueForKey("searchFromDate.osx") as? NSDate {
+        if let currentSearchFromDate = self.settings.value(forKey: "searchFromDate.osx") as? Date {
             self.currentFromDate = currentSearchFromDate
             shouldUpdateUI = true
         }
 
-        if let currentSearchToDate = self.settings.valueForKey("searchToDate.osx") as? NSDate {
+        if let currentSearchToDate = self.settings.value(forKey: "searchToDate.osx") as? Date {
             self.currentToDate = currentSearchToDate
             shouldUpdateUI = true
         }
@@ -277,7 +277,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         // Filter Types
         //
         
-        if let filterTypes = self.settings.valueForKey("filterTypes.osx") as? NSArray {
+        if let filterTypes = self.settings.value(forKey: "filterTypes.osx") as? NSArray {
             self.currentFilterTypes = NSMutableArray(array: filterTypes as [AnyObject], copyItems: true)
             shouldUpdateUI = true
         } else {
@@ -288,7 +288,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         // Filter Name
         //
         
-        if let filterName = self.settings.valueForKey("filterName.osx") as? NSString {
+        if let filterName = self.settings.value(forKey: "filterName.osx") as? NSString {
             self.currentFilterName = filterName
             shouldUpdateUI = true
         } else {
@@ -306,7 +306,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     
     // Update search settings
     func updateSearchSettings() {
-        self.settings = NSUserDefaults.standardUserDefaults()
+        self.settings = UserDefaults.standard
         self.settings.synchronize()
         
         self.settings.setValue(self.currentFromDate, forKey: "searchFromDate.osx")
@@ -317,7 +317,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     
     // Update search labels & views
     func updateSearchLabelsAndViews() {
-        let dateFormatter = NSDateFormatter()
+        let dateFormatter = DateFormatter()
     
         // Set format for text views
         dateFormatter.dateFormat = NSLocalizedString("MMM, d yyyy", comment: "")
@@ -344,43 +344,43 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         }
     }
     
-    func numberOfRowsInTableView(aTableView: NSTableView) -> Int {
+    func numberOfRows(in aTableView: NSTableView) -> Int {
         let numberOfRows:Int = self.expenses.count
         return numberOfRows
     }
     
     // Format & Display Row Cells
-    func tableView(tableView: NSTableView, viewForTableColumn tableColumn: NSTableColumn?, row: Int) -> NSView? {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
         
         let cellIdentifier = NSString(format: "%@Cell", tableColumn!.identifier) as String!
         
-        let result: NSTableCellView = self.expensesTableView.makeViewWithIdentifier(cellIdentifier, owner: self.expensesTableView) as! NSTableCellView
+        let result: NSTableCellView = self.expensesTableView.make(withIdentifier: cellIdentifier!, owner: self.expensesTableView) as! NSTableCellView
         
-        var stringValue: AnyObject? = self.expenses.objectAtIndex( row ).valueForKey( tableColumn!.identifier )
+        var stringValue: AnyObject? = (self.expenses.object( at: row ) as AnyObject).value( forKey: tableColumn!.identifier ) as AnyObject
         
         // Format Value
         if ( tableColumn!.identifier == "value" ) {
-            let numberFormatter = NSNumberFormatter()
-            numberFormatter.locale = NSLocale.currentLocale()
-            numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
+            let numberFormatter = NumberFormatter()
+            numberFormatter.locale = Locale.current
+            numberFormatter.numberStyle = NumberFormatter.Style.decimal
             
-            stringValue = NSString(format:"%@", numberFormatter.stringFromNumber(NSNumber(float: stringValue as! Float))!)
+            stringValue = NSString(format:"%@", numberFormatter.string(from: NSNumber(value: stringValue as! Float as Float))!)
         }
         
         // Format Date
         if ( tableColumn!.identifier == "date" ) {
-            let dateFormatter = NSDateFormatter()
+            let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = NSLocalizedString("MMM, d", comment:"")
-            let locale = NSLocale(localeIdentifier: NSLocalizedString("en_US", comment:""))
+            let locale = Locale(identifier: NSLocalizedString("en_US", comment:""))
             dateFormatter.locale = locale
             
-            stringValue = dateFormatter.stringFromDate(stringValue as! NSDate)
+            stringValue = dateFormatter.string(from: stringValue! as! Date) as NSString
         }
         
         // Format Type
         if ( tableColumn!.identifier == "type" ) {
             if ( stringValue == nil ) {
-                stringValue = "—"
+                stringValue = "—" as NSString
             }
         }
         
@@ -391,12 +391,12 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     
     // Get all expense types
     func getAllExpenseTypes() {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let entityDesc = NSEntityDescription.entityForName("ExpenseType", inManagedObjectContext:context!)
+        let entityDesc = NSEntityDescription.entity(forEntityName: "ExpenseType", in:context!)
         
-        let request = NSFetchRequest()
+        let request = NSFetchRequest<NSFetchRequestResult>()
         request.entity = entityDesc
         
         // Sort expenses by name
@@ -412,7 +412,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         var objects: NSArray
         
         let error: NSError? = nil
-        objects = try! context!.executeFetchRequest(request)
+        objects = try! context!.fetch(request) as NSArray
         
         if ( error != nil ) {
             objects = []
@@ -422,7 +422,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         
         // Add Uncategorized on the beginning of the array
         let uncategorizedObject: [String: String] = [ "name": uncategorizedStringValue ]
-        objectsCopy.insertObject( uncategorizedObject, atIndex: 0)
+        objectsCopy.insert( uncategorizedObject, at: 0)
         
         if ( objectsCopy.count == 0 ) {
             /*let alertView = NSAlert()
@@ -440,31 +440,31 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     }
     
     // Get a sum of all expenses for a given expense type (between dates)
-    func getExpenseTypeSum( expenseTypeName: NSString ) -> Float {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    func getExpenseTypeSum( _ expenseTypeName: NSString ) -> Float {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let entityDesc = NSEntityDescription.entityForName("Expense", inManagedObjectContext:context!)
+        let entityDesc = NSEntityDescription.entity(forEntityName: "Expense", in:context!)
         
-        let request = NSFetchRequest()
+        let request = NSFetchRequest<NSFetchRequestResult>()
         request.entity = entityDesc
         
         let usedPredicates = NSMutableArray()
         
         // Add dates to search
-        let datesPredicate = NSPredicate(format: "(date >= %@) and (date <= %@)", self.currentFromDate, self.currentToDate)
+        let datesPredicate = NSPredicate(format: "(date >= %@) and (date <= %@)", self.currentFromDate as! CVarArg, self.currentToDate as! CVarArg)
         
-        usedPredicates.addObject(datesPredicate)
+        usedPredicates.add(datesPredicate)
         
         // Add expense type name to search
         var filterNamePredicate: NSPredicate = NSPredicate(format: "(type =[c] %@)", expenseTypeName)
         
         // Search for nil when trying to find uncategorized
-        if ( expenseTypeName == uncategorizedStringValue ) {
+        if ( expenseTypeName as String == uncategorizedStringValue ) {
             filterNamePredicate = NSPredicate(format: "(type = nil)")
         }
         
-        usedPredicates.addObject(filterNamePredicate)
+        usedPredicates.add(filterNamePredicate)
         
         // Add the predicate to the request
         let finalPredicate: NSPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: usedPredicates as AnyObject as! [NSPredicate])
@@ -477,7 +477,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         var objects: NSArray
         
         let error: NSError? = nil
-        objects = try! context!.executeFetchRequest(request)
+        objects = try! context!.fetch(request) as NSArray
         
         if ( error != nil ) {
             objects = []
@@ -486,13 +486,13 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         var total: Float = 0
         
         for object in objects {
-            total += object.valueForKey("value") as! Float
+            total += (object as AnyObject).value(forKey: "value") as! Float
         }
         
         return total
     }
     
-    override func prepareForSegue(segue: NSStoryboardSegue, sender: AnyObject?) {
+    override func prepare(for segue: NSStoryboardSegue, sender: Any?) {
         // Assign mainViewController
         if segue.identifier == "editExpense" {
             let viewController = segue.destinationController as! EditExpenseViewController
@@ -502,7 +502,7 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
     }
     
     // Clicking on a row to view an expense
-    @IBAction func showExpense(sender: AnyObject) {
+    @IBAction func showExpense(_ sender: AnyObject) {
         let selectedRowIndex = self.expensesTableView.selectedRow
         
         // If the index is -1 means nothing is selected, but this event was triggered still
@@ -511,12 +511,12 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
             self.selectedExpenseIndex = selectedRowIndex
             
             // Show popover
-            self.performSegueWithIdentifier("editExpense", sender: self)
+            self.performSegue(withIdentifier: "editExpense", sender: self)
         }
     }
     
     // iCloud just finished updating
-    @IBAction func iCloudDidUpdate( sender: AnyObject? ) {
+    @IBAction func iCloudDidUpdate( _ sender: AnyObject? ) {
         // TODO: This is causing some unnecessary instability
         /*// This was creating an infinite loop, so we only allow this to run once every minute tops.
         let codeHasRunInThePastMinute: Bool

--- a/Oikon/ExpensesListViewController.swift
+++ b/Oikon/ExpensesListViewController.swift
@@ -379,7 +379,9 @@ class ExpensesListViewController: NSViewController, NSTableViewDataSource, NSTab
         
         // Format Type
         if ( tableColumn!.identifier == "type" ) {
-            if ( stringValue == nil ) {
+            if let testing = stringValue as? String {
+                // Do nothing
+            } else {
                 stringValue = "—" as NSString
             }
         }

--- a/Oikon/Info.plist
+++ b/Oikon/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.finance</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Oikon/SettingsViewController.swift
+++ b/Oikon/SettingsViewController.swift
@@ -12,18 +12,18 @@ class SettingsViewController: NSViewController {
     
     var mainViewController: ViewController!
     
-    var settings: NSUserDefaults!
+    var settings: UserDefaults!
     
-    var lastiCloudFetch: NSDate?
+    var lastiCloudFetch: Date?
     
     @IBOutlet weak var lastSyncLabel: NSTextField!
     @IBOutlet weak var iCloudSwitch: NSButton!
     
     // Remove all data
-    @IBAction func removeAllData(sender: AnyObject) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    @IBAction func removeAllData(_ sender: AnyObject) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         
-        let buttonPressed = self.mainViewController.showConfirm( NSLocalizedString("This will remove all local & iCloud data, including expenses, and expense types", comment: "") )
+        let buttonPressed = self.mainViewController.showConfirm( NSLocalizedString("This will remove all local & iCloud data, including expenses, and expense types", comment: "") as NSString )
         
         // Confirmed!
         if buttonPressed == NSAlertSecondButtonReturn {
@@ -32,8 +32,8 @@ class SettingsViewController: NSViewController {
     }
 
     // Toggle iCloud sync
-    @IBAction func toggleiCloudSync(sender: AnyObject) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    @IBAction func toggleiCloudSync(_ sender: AnyObject) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let checkbox: NSButton = sender as! NSButton
         
         self.updateSettings()
@@ -49,14 +49,14 @@ class SettingsViewController: NSViewController {
     
     // Fetch settings
     func fetchSettings() {
-        self.settings = NSUserDefaults.standardUserDefaults()
+        self.settings = UserDefaults.standard
         self.settings.synchronize()
         
-        NSLog("%@", self.settings.objectForKey("iCloud.osx") as! NSMutableDictionary)
+        NSLog("%@", self.settings.object(forKey: "iCloud.osx") as! NSMutableDictionary)
         
-        let iCloudSettings: NSMutableDictionary = self.settings.objectForKey("iCloud.osx") as! NSMutableDictionary
-        let isiCloudEnabled: Bool = iCloudSettings.valueForKey("isEnabled") as! Bool
-        let lastSync: NSDate? = iCloudSettings.valueForKey("lastSuccessfulSync") as? NSDate
+        let iCloudSettings: NSMutableDictionary = self.settings.object(forKey: "iCloud.osx") as! NSMutableDictionary
+        let isiCloudEnabled: Bool = iCloudSettings.value(forKey: "isEnabled") as! Bool
+        let lastSync: Date? = iCloudSettings.value(forKey: "lastSuccessfulSync") as? Date
         
         // Update checkbox
         if ( isiCloudEnabled == true ) {
@@ -65,14 +65,14 @@ class SettingsViewController: NSViewController {
             self.iCloudSwitch.state = NSOffState
         }
         
-        let dateFormatter = NSDateFormatter()
-        dateFormatter.locale = NSLocale.currentLocale()
-        dateFormatter.dateStyle = NSDateFormatterStyle.ShortStyle
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale.current
+        dateFormatter.dateStyle = DateFormatter.Style.short
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         
         // Update label
         if ( lastSync != nil ) {
-            self.lastSyncLabel.stringValue = dateFormatter.stringFromDate(lastSync!)
+            self.lastSyncLabel.stringValue = dateFormatter.string(from: lastSync!)
         } else {
             self.lastSyncLabel.stringValue = NSLocalizedString("N/A", comment:"")
         }
@@ -80,10 +80,10 @@ class SettingsViewController: NSViewController {
     
     // Update settings
     func updateSettings() {
-        self.settings = NSUserDefaults.standardUserDefaults()
+        self.settings = UserDefaults.standard
         self.settings.synchronize()
         
-        let iCloudSettings: NSMutableDictionary = self.settings.objectForKey("iCloud.osx")!.mutableCopy() as! NSMutableDictionary
+        let iCloudSettings: NSMutableDictionary = (self.settings.object(forKey: "iCloud.osx") as! NSDictionary!).mutableCopy() as! NSMutableDictionary
         var isiCloudEnabled: Bool = false
         
         // Update checkbox status
@@ -93,7 +93,7 @@ class SettingsViewController: NSViewController {
 
         iCloudSettings.setValue(isiCloudEnabled, forKey: "isEnabled")
         
-        self.settings.setObject(iCloudSettings, forKey: "iCloud.osx")
+        self.settings.set(iCloudSettings, forKey: "iCloud.osx")
     }
 
     override func viewDidLoad() {
@@ -101,7 +101,7 @@ class SettingsViewController: NSViewController {
         // Do view setup here.
         
         // Listen for iCloud changes (after it's done)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "iCloudDidUpdate:", name: NSPersistentStoreCoordinatorStoresDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: "iCloudDidUpdate:", name: NSNotification.Name.NSPersistentStoreCoordinatorStoresDidChange, object: nil)
     }
     
     override func viewWillAppear() {
@@ -109,7 +109,7 @@ class SettingsViewController: NSViewController {
     }
     
     // iCloud just finished updating
-    @IBAction func iCloudDidUpdate( sender: AnyObject? ) {
+    @IBAction func iCloudDidUpdate( _ sender: AnyObject? ) {
         // TODO: This is causing some unnecessary instability
         /*// This was creating an infinite loop, so we only allow this to run once every minute tops.
         let codeHasRunInThePastMinute: Bool

--- a/Oikon/ViewController.swift
+++ b/Oikon/ViewController.swift
@@ -18,58 +18,58 @@ class ViewController: NSViewController {
         // Do any additional setup after loading the view.
         self.thisController = self
         
-        let application = NSApplication.sharedApplication()
+        let application = NSApplication.shared()
         let fileString = NSLocalizedString("File", comment:"")
 
         let preferencesString = NSLocalizedString("Preferences…", comment:"")
         let exportString = NSLocalizedString("Export CSV…", comment:"")
         let importString = NSLocalizedString("Import CSV…", comment:"")
         
-        let oikonMenuItem = application.mainMenu?.itemWithTitle("Oikon")!
-        let fileMenuItem = application.mainMenu?.itemWithTitle(fileString)!
+        let oikonMenuItem = application.mainMenu?.item(withTitle: "Oikon")!
+        let fileMenuItem = application.mainMenu?.item(withTitle: fileString)!
 
-        let preferencesMenuItem = (oikonMenuItem!.submenu?.itemWithTitle(preferencesString))!
-        let exportMenuItem = (fileMenuItem!.submenu?.itemWithTitle(exportString))!
-        let importMenuItem = (fileMenuItem!.submenu?.itemWithTitle(importString))!
+        let preferencesMenuItem = (oikonMenuItem!.submenu?.item(withTitle: preferencesString))!
+        let exportMenuItem = (fileMenuItem!.submenu?.item(withTitle: exportString))!
+        let importMenuItem = (fileMenuItem!.submenu?.item(withTitle: importString))!
         
         // Add action to "Preferences..." menu item
-        preferencesMenuItem.action = Selector("openPreferences:")
-        preferencesMenuItem.enabled = true
+        preferencesMenuItem.action = #selector(ViewController.openPreferences(_:))
+        preferencesMenuItem.isEnabled = true
         preferencesMenuItem.target = self
         
         // Add action to "Export CSV..." menu item
-        exportMenuItem.action = Selector("exportCSV:")
-        exportMenuItem.enabled = true
+        exportMenuItem.action = #selector(ViewController.exportCSV(_:))
+        exportMenuItem.isEnabled = true
         exportMenuItem.target = self
         
         // Add action to "Import CSV..." menu item
-        importMenuItem.action = Selector("importCSV:")
-        importMenuItem.enabled = true
+        importMenuItem.action = #selector(ViewController.importCSV(_:))
+        importMenuItem.isEnabled = true
         importMenuItem.target = self
     }
     
     // Formats the date for the CSV file
-    func formatDateForCSV( date: NSDate ) -> NSString {
-        let dateFormatter = NSDateFormatter()
-        let locale = NSLocale(localeIdentifier: "en_US")
+    func formatDateForCSV( _ date: Date ) -> NSString {
+        let dateFormatter = DateFormatter()
+        let locale = Locale(identifier: "en_US")
 
         dateFormatter.locale = locale
-        dateFormatter.dateStyle = NSDateFormatterStyle.ShortStyle
+        dateFormatter.dateStyle = DateFormatter.Style.short
         dateFormatter.dateFormat = "yyyy-MM-dd"
 
-        let formattedDate = dateFormatter.stringFromDate(date)
+        let formattedDate = dateFormatter.string(from: date)
 
-        return formattedDate
+        return formattedDate as NSString
     }
     
     // Get all expenses, for CSV
     func getAllExpenses() -> [NSManagedObject] {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let entityDesc = NSEntityDescription.entityForName("Expense", inManagedObjectContext:context!)
+        let entityDesc = NSEntityDescription.entity(forEntityName: "Expense", in:context!)
         
-        let request = NSFetchRequest()
+        let request = NSFetchRequest<NSFetchRequestResult>()
         request.entity = entityDesc
         
         // Sort expenses by date
@@ -81,7 +81,7 @@ class ViewController: NSViewController {
         var objects: NSArray
         
         let error: NSError? = nil
-        objects = try! context!.executeFetchRequest(request)
+        objects = try! context!.fetch(request) as NSArray
         
         if ( error != nil ) {
             objects = []
@@ -95,44 +95,44 @@ class ViewController: NSViewController {
         var fileContents:NSString = ""
         
         // Add Header
-        fileContents = fileContents.stringByAppendingString("Name,Type,Date,Value")
+        fileContents = fileContents.appending("Name,Type,Date,Value") as NSString
 
         let expenses = self.getAllExpenses()
 
         for expense: NSManagedObject in expenses {
             // Parse the values for text from the received object
-            var expenseValue: NSString = NSString(format: "%0.2f", expense.valueForKey("value")!.floatValue)
-            var expenseName: NSString = expense.valueForKey("name")! as! NSString
+            var expenseValue: NSString = NSString(format: "%0.2f", (expense.value(forKey: "value")! as AnyObject).floatValue)
+            var expenseName: NSString = expense.value(forKey: "name")! as! NSString
             var expenseType: NSString
-            if expense.valueForKey("type") != nil {
-                expenseType = expense.valueForKey("type")! as! NSString
+            if expense.value(forKey: "type") != nil {
+                expenseType = expense.value(forKey: "type")! as! NSString
             } else {
                 // Show "uncategorized" if nothing is set
                 expenseType = "uncategorized"// This is not translated on purpose, so it's a "standard" for the CSV
             }
-            var expenseDate = self.formatDateForCSV(expense.valueForKey("date")! as! NSDate)
+            var expenseDate = self.formatDateForCSV(expense.value(forKey: "date")! as! Date)
             
             // parse commas, new lines, and quotes for CSV
-            expenseName = expenseName.stringByReplacingOccurrencesOfString(",", withString: ";")
-            expenseName = expenseName.stringByReplacingOccurrencesOfString("\n", withString: " ")
-            expenseName = expenseName.stringByReplacingOccurrencesOfString("\"", withString: "'")
+            expenseName = expenseName.replacingOccurrences(of: ",", with: ";") as NSString
+            expenseName = expenseName.replacingOccurrences(of: "\n", with: " ") as NSString
+            expenseName = expenseName.replacingOccurrences(of: "\"", with: "'") as NSString
             
-            expenseType = expenseType.stringByReplacingOccurrencesOfString(",", withString: ";")
-            expenseType = expenseType.stringByReplacingOccurrencesOfString("\n", withString: " ")
-            expenseType = expenseType.stringByReplacingOccurrencesOfString("\"", withString: "'")
+            expenseType = expenseType.replacingOccurrences(of: ",", with: ";") as NSString
+            expenseType = expenseType.replacingOccurrences(of: "\n", with: " ") as NSString
+            expenseType = expenseType.replacingOccurrences(of: "\"", with: "'") as NSString
             
-            expenseDate = expenseDate.stringByReplacingOccurrencesOfString(",", withString: ";")
-            expenseDate = expenseDate.stringByReplacingOccurrencesOfString("\n", withString: " ")
-            expenseDate = expenseDate.stringByReplacingOccurrencesOfString("\"", withString: "'")
+            expenseDate = expenseDate.replacingOccurrences(of: ",", with: ";") as NSString
+            expenseDate = expenseDate.replacingOccurrences(of: "\n", with: " ") as NSString
+            expenseDate = expenseDate.replacingOccurrences(of: "\"", with: "'") as NSString
             
-            expenseValue = expenseValue.stringByReplacingOccurrencesOfString(",", withString: ";")
-            expenseValue = expenseValue.stringByReplacingOccurrencesOfString("\n", withString: " ")
-            expenseValue = expenseValue.stringByReplacingOccurrencesOfString("\"", withString: "'")
+            expenseValue = expenseValue.replacingOccurrences(of: ",", with: ";") as NSString
+            expenseValue = expenseValue.replacingOccurrences(of: "\n", with: " ") as NSString
+            expenseValue = expenseValue.replacingOccurrences(of: "\"", with: "'") as NSString
             
             let rowForExpense = NSString(format:"\n%@,%@,%@,%@", expenseName, expenseType, expenseDate, expenseValue)
             
             // Append string to file contents
-            fileContents = fileContents.stringByAppendingString(rowForExpense as String)
+            fileContents = fileContents.appending(rowForExpense as String) as NSString
         }
         
         //NSLog("Final file contents:\n\n%@", fileContents);
@@ -141,7 +141,7 @@ class ViewController: NSViewController {
     }
     
     // Export CSV...
-    func exportCSV( sender: AnyObject? ) {
+    func exportCSV( _ sender: AnyObject? ) {
         // Show panel to select a directory
         let panel: NSOpenPanel = NSOpenPanel()
         panel.allowsMultipleSelection = false
@@ -149,9 +149,9 @@ class ViewController: NSViewController {
         panel.canChooseFiles = false
         panel.prompt = NSLocalizedString("Choose", comment: "")
         panel.title = NSLocalizedString("Select a directory to export the CSV file into.", comment: "")
-        panel.beginWithCompletionHandler { (result) -> Void in
+        panel.begin { (result) -> Void in
             if result == NSFileHandlingPanelOKButton {
-                let csvFileName: NSURL = panel.URL!.URLByAppendingPathComponent(NSString(format:"oikon-export-%d.csv", Int(NSDate().timeIntervalSince1970)) as String)
+                let csvFileName: URL = panel.url!.appendingPathComponent(NSString(format:"oikon-export-%d.csv", Int(Date().timeIntervalSince1970)) as String)
                 let csvFileContents = self.getCSVFileString()
                 
                 self.saveCSVFile(csvFileName, contents: csvFileContents)
@@ -160,12 +160,12 @@ class ViewController: NSViewController {
     }
     
     // Actually save the CSV file
-    func saveCSVFile( name: NSURL, contents: NSString ) {
+    func saveCSVFile( _ name: URL, contents: NSString ) {
         
         var error: NSError? = nil
         
         do {
-            try contents.writeToFile(name.path!, atomically: true, encoding: NSUTF8StringEncoding)
+            try contents.write(toFile: name.path, atomically: true, encoding: String.Encoding.utf8.rawValue)
         } catch let error1 as NSError {
             error = error1
         }
@@ -174,19 +174,19 @@ class ViewController: NSViewController {
             // Notify the file was saved
             let notification: NSUserNotification = NSUserNotification()
             notification.title = NSLocalizedString("CSV File saved!", comment:"")
-            notification.informativeText = NSString(format: NSLocalizedString("The file %@ was saved successfully.", comment:""), name.lastPathComponent!) as String
+            notification.informativeText = NSString(format: NSLocalizedString("The file %@ was saved successfully.", comment:"") as NSString, name.lastPathComponent) as String
             notification.soundName = NSUserNotificationDefaultSoundName
             
-            NSUserNotificationCenter.defaultUserNotificationCenter().deliverNotification(notification)
+            NSUserNotificationCenter.default.deliver(notification)
         } else {
             NSLog("Error: %@", error!)
             
-            self.showAlert(NSLocalizedString("There was an error saving the export.", comment:""), window: self.view.window!)
+            self.showAlert(NSLocalizedString("There was an error saving the export.", comment:"") as NSString, window: self.view.window!)
         }
     }
     
     // Import CSV...
-    func importCSV( sender: AnyObject? ) {
+    func importCSV( _ sender: AnyObject? ) {
         // Show panel to select a file
         let panel: NSOpenPanel = NSOpenPanel()
         panel.showsHiddenFiles = false
@@ -196,11 +196,11 @@ class ViewController: NSViewController {
         panel.allowedFileTypes = ["csv", "CSV"]
         panel.prompt = NSLocalizedString("Choose", comment: "")
         panel.title = NSLocalizedString("Choose the CSV file to import data from.", comment: "")
-        panel.beginWithCompletionHandler { (result) -> Void in
+        panel.begin { (result) -> Void in
             if result == NSFileHandlingPanelOKButton {
-                let csvFileName: NSURL = panel.URL!
-                let csvFileData: NSData = NSData(contentsOfURL: csvFileName)!
-                let csvFileContents: NSString = NSString(data: csvFileData, encoding: NSUTF8StringEncoding)!
+                let csvFileName: URL = panel.url!
+                let csvFileData: Data = try! Data(contentsOf: csvFileName)
+                let csvFileContents: NSString = NSString(data: csvFileData, encoding: String.Encoding.utf8.rawValue)!
                 
                 //NSLog("File contents:\n\n%@", csvFileContents)
                 
@@ -210,29 +210,29 @@ class ViewController: NSViewController {
     }
     
     // Actually import the CSV file
-    func importCSVFile( name: NSURL, contents: NSString ) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    func importCSVFile( _ name: URL, contents: NSString ) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
 
-        let locale = NSLocale(localeIdentifier: "en_US")
+        let locale = Locale(identifier: "en_US")
 
-        let dateFormatter = NSDateFormatter()
+        let dateFormatter = DateFormatter()
         dateFormatter.locale = locale
-        dateFormatter.dateStyle = NSDateFormatterStyle.ShortStyle
+        dateFormatter.dateStyle = DateFormatter.Style.short
         dateFormatter.dateFormat = "yyyy-MM-dd"
         
-        let numberFormatter = NSNumberFormatter()
+        let numberFormatter = NumberFormatter()
         numberFormatter.locale = locale
-        numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
+        numberFormatter.numberStyle = NumberFormatter.Style.decimal
 
         // Ask if merge, replace, or cancel
         var action = "merge"
         let alertView = NSAlert()
         
-        alertView.addButtonWithTitle(NSLocalizedString("Cancel", comment: ""))
-        alertView.addButtonWithTitle(NSLocalizedString("Replace", comment: ""))
-        alertView.addButtonWithTitle(NSLocalizedString("Merge", comment: ""))
-        alertView.alertStyle = NSAlertStyle.CriticalAlertStyle
+        alertView.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
+        alertView.addButton(withTitle: NSLocalizedString("Replace", comment: ""))
+        alertView.addButton(withTitle: NSLocalizedString("Merge", comment: ""))
+        alertView.alertStyle = NSAlertStyle.critical
         
         alertView.messageText = NSLocalizedString("Do you want to replace all data (will remove everything before importing) or merge it? Duplicates might appear if you're merging.", comment:"")
         alertView.informativeText = NSLocalizedString("This action is irreversible.", comment:"")
@@ -260,7 +260,7 @@ class ViewController: NSViewController {
             appDelegate.removeAllData()
         }
         
-        let csvRows = contents.componentsSeparatedByString("\n")
+        let csvRows = contents.components(separatedBy: "\n")
         
         for csvRow in csvRows {
             // Skip header
@@ -268,15 +268,15 @@ class ViewController: NSViewController {
                 continue
             }
             
-            let csvData = csvRow.componentsSeparatedByString(",")
+            let csvData = csvRow.components(separatedBy: ",")
             
             //
             // Parse values
             
             let expenseName: NSString = csvData[0] as NSString
-            var expenseType: NSString? = csvData[1] as? NSString
-            let expenseDate: NSDate = dateFormatter.dateFromString( csvData[2] )!
-            let expenseValue: NSNumber = numberFormatter.numberFromString( csvData[3] )!
+            var expenseType: NSString? = csvData[1] as NSString
+            let expenseDate: Date = dateFormatter.date( from: csvData[2] )!
+            let expenseValue: NSNumber = numberFormatter.number( from: csvData[3] )!
             
             // If the type is "uncategorized" (not translated on purpose), make it nil
             if ( expenseType == "uncategorized" ) {
@@ -286,7 +286,7 @@ class ViewController: NSViewController {
             //
             // Add expense
             
-            let newExpense: NSManagedObject = NSEntityDescription.insertNewObjectForEntityForName("Expense", inManagedObjectContext: context!) 
+            let newExpense: NSManagedObject = NSEntityDescription.insertNewObject(forEntityName: "Expense", into: context!) 
             newExpense.setValue(expenseValue, forKey: "value")
             newExpense.setValue(expenseName, forKey: "name")
             newExpense.setValue(expenseType, forKey: "type")
@@ -302,7 +302,7 @@ class ViewController: NSViewController {
             if ( error != nil ) {
                 NSLog("Error: %@", error!)
                 
-                self.showAlert(NSString(format:NSLocalizedString("There was an error adding an expense. Please confirm the value types match for line '%@'.", comment:""), csvRow ), window: self.view.window!)
+                self.showAlert(NSString(format:NSLocalizedString("There was an error adding an expense. Please confirm the value types match for line '%@'.", comment:"") as NSString, csvRow ), window: self.view.window!)
             }
             
             // Add Expense Type if it doesn't exist
@@ -316,18 +316,18 @@ class ViewController: NSViewController {
         // Notify the import has finished
         let notification: NSUserNotification = NSUserNotification()
         notification.title = NSLocalizedString("CSV File imported!", comment:"")
-        notification.informativeText = NSString(format: NSLocalizedString("The file %@ was imported successfully.", comment:""), name.lastPathComponent!) as String
+        notification.informativeText = NSString(format: NSLocalizedString("The file %@ was imported successfully.", comment:"") as NSString, name.lastPathComponent) as String
         notification.soundName = NSUserNotificationDefaultSoundName
         
-        NSUserNotificationCenter.defaultUserNotificationCenter().deliverNotification(notification)
+        NSUserNotificationCenter.default.deliver(notification)
     }
     
     // Add Expense Type
-    func addExpenseType( name: NSString ) {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    func addExpenseType( _ name: NSString ) {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
 
-        let newExpenseType: NSManagedObject = NSEntityDescription.insertNewObjectForEntityForName("ExpenseType", inManagedObjectContext: context!) 
+        let newExpenseType: NSManagedObject = NSEntityDescription.insertNewObject(forEntityName: "ExpenseType", into: context!) 
         
         newExpenseType.setValue(name, forKey: "name")
         
@@ -341,18 +341,18 @@ class ViewController: NSViewController {
         if ( error != nil ) {
             NSLog("Error: %@", error!)
             
-            self.showAlert(NSString(format:NSLocalizedString("There was an error adding your expense type. Please confirm the value types match for '%@'.", comment:""), name), window: self.view.window!)
+            self.showAlert(NSString(format:NSLocalizedString("There was an error adding your expense type. Please confirm the value types match for '%@'.", comment:"") as NSString, name), window: self.view.window!)
         }
     }
     
     // Check if an expense type name already exists
-    func expenseTypeExists( expenseTypeName: NSString ) -> Bool {
-        let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate
+    func expenseTypeExists( _ expenseTypeName: NSString ) -> Bool {
+        let appDelegate = NSApplication.shared().delegate as! AppDelegate
         let context = appDelegate.managedObjectContext
         
-        let entityDesc = NSEntityDescription.entityForName("ExpenseType", inManagedObjectContext:context!)
+        let entityDesc = NSEntityDescription.entity(forEntityName: "ExpenseType", in:context!)
         
-        let request = NSFetchRequest()
+        let request = NSFetchRequest<NSFetchRequestResult>()
         request.entity = entityDesc
         
         // Add expense type name to search
@@ -366,7 +366,7 @@ class ViewController: NSViewController {
         var objects: NSArray
         
         let error: NSError? = nil
-        objects = try! context!.executeFetchRequest(request)
+        objects = try! context!.fetch(request) as NSArray
         
         if ( error != nil ) {
             objects = []
@@ -376,20 +376,20 @@ class ViewController: NSViewController {
     }
     
     // Open settings (Preferences... menu item)
-    func openPreferences( sender: AnyObject? ) {
-        self.performSegueWithIdentifier("settings", sender: self)
+    func openPreferences( _ sender: AnyObject? ) {
+        self.performSegue(withIdentifier: "settings", sender: self)
     }
 
-    override var representedObject: AnyObject? {
+    override var representedObject: Any? {
         didSet {
         // Update the view, if already loaded.
         }
     }
 
-    override func prepareForSegue(segue: NSStoryboardSegue, sender: AnyObject?) {
+    override func prepare(for segue: NSStoryboardSegue, sender: Any?) {
         // Assign each "side" view controllers to each one
         if segue.identifier == "pastExpensesOpen" {
-            let viewItems = segue.destinationController.splitViewItems as [NSSplitViewItem]
+            let viewItems = (segue.destinationController as AnyObject).splitViewItems as [NSSplitViewItem]
 
             let listController = viewItems[0].viewController as! ExpensesListViewController
             let sidebarController = viewItems[1].viewController as! ExpensesListSidebarViewController
@@ -421,42 +421,42 @@ class ViewController: NSViewController {
     }
     
     // Change "uncategorized" with ""
-    func parseFilterTypes( filterTypes: NSMutableArray ) -> NSMutableArray {
+    func parseFilterTypes( _ filterTypes: NSMutableArray ) -> NSMutableArray {
         let parsedFilterTypes = NSMutableArray(array: filterTypes as [AnyObject], copyItems: true)
         
         let uncategorizedText = NSLocalizedString("uncategorized", comment: "")
         
-        let uncategorizedIndex = parsedFilterTypes.indexOfObject(uncategorizedText)
+        let uncategorizedIndex = parsedFilterTypes.index(of: uncategorizedText)
     
-        let hasUncategorized:Bool = parsedFilterTypes.containsObject(uncategorizedText)
+        let hasUncategorized:Bool = parsedFilterTypes.contains(uncategorizedText)
     
         // Check if the uncategorized exists in the array
         if ( hasUncategorized ) {
             // Remove item in the array
-            parsedFilterTypes.removeObjectAtIndex(uncategorizedIndex)
+            parsedFilterTypes.removeObject(at: uncategorizedIndex)
         }
     
         return parsedFilterTypes
     }
     
     // Show simple alert
-    func showAlert( message: NSString, window: NSWindow ) {
+    func showAlert( _ message: NSString, window: NSWindow ) {
         let alertView = NSAlert()
 
-        alertView.addButtonWithTitle(NSLocalizedString("OK", comment: ""))
+        alertView.addButton(withTitle: NSLocalizedString("OK", comment: ""))
         alertView.messageText = message as String
-        alertView.alertStyle = NSAlertStyle.WarningAlertStyle
+        alertView.alertStyle = NSAlertStyle.warning
 
-        alertView.beginSheetModalForWindow(window, completionHandler: nil)
+        alertView.beginSheetModal(for: window, completionHandler: nil)
     }
     
     // Show confirm dialog
-    func showConfirm( message: NSString ) -> NSModalResponse {
+    func showConfirm( _ message: NSString ) -> NSModalResponse {
         let alertView = NSAlert()
 
-        alertView.addButtonWithTitle(NSLocalizedString("Cancel", comment: ""))
-        alertView.addButtonWithTitle(NSLocalizedString("Delete", comment: ""))
-        alertView.alertStyle = NSAlertStyle.CriticalAlertStyle
+        alertView.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
+        alertView.addButton(withTitle: NSLocalizedString("Delete", comment: ""))
+        alertView.alertStyle = NSAlertStyle.critical
         
         alertView.messageText = message as String
         alertView.informativeText = NSLocalizedString("This action is irreversible.", comment:"")

--- a/Oikon/ViewController.swift
+++ b/Oikon/ViewController.swift
@@ -262,6 +262,12 @@ class ViewController: NSViewController {
         
         let csvRows = contents.components(separatedBy: "\n")
         
+        // Check if the first row matches the expected format, or error out
+        if csvRows[0] != "Name,Type,Date,Value" {
+            self.showAlert(NSLocalizedString("There was an error parsing the CSV file. Please make sure the first line is 'Name,Type,Date,Value', and the following lines follow that format with the values.", comment:"") as NSString, window: self.view.window!)
+            return
+        }
+        
         for csvRow in csvRows {
             // Skip header
             if csvRow == "Name,Type,Date,Value" {

--- a/Oikon/WindowController.swift
+++ b/Oikon/WindowController.swift
@@ -15,7 +15,7 @@ class WindowController: NSWindowController {
         NSLog("Window loaded!")
 
         // Unify title bar
-        self.window!.titleVisibility = NSWindowTitleVisibility.Hidden
+        self.window!.titleVisibility = NSWindowTitleVisibility.hidden
         self.window!.titlebarAppearsTransparent = true
     }
 }

--- a/OikonTests/OikonTests.swift
+++ b/OikonTests/OikonTests.swift
@@ -28,7 +28,7 @@ class OikonTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock() {
+        self.measure() {
             // Put the code you want to measure the time of here.
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oikon Mac
 
-This is the code for the Oikon OS X app, available at http://oikon.us
+This is the code for the Oikon OS X app, available at https://oikon.net
 
 It's open for everyone to contribute to.
 


### PR DESCRIPTION
Still just updating code to Swift 3.0 (listing of expenses isn't working yet).

# To-dos
- [x] Update code and UI/Storyboard to latest Xcode
- [x] Make clearing of search work (#3)
- [x] Automatically trim expense name on adding expense (#4)
- [x] Automatically accept `,` or `.` as decimal points
- [x] Allow having more than one window open at the same time
- [x] Don't crash on a bad CSV (and show an error instead) (#5)